### PR TITLE
Added Capability for custom mosaicing bins

### DIFF
--- a/batanalysis/_version.py
+++ b/batanalysis/_version.py
@@ -1,4 +1,4 @@
 """
 This file is simply meant to define the version of the software to be used elsewhere.
 """
-__version__ = "1.0.6"
+__version__ = "1.0.7"

--- a/batanalysis/_version.py
+++ b/batanalysis/_version.py
@@ -1,4 +1,4 @@
 """
 This file is simply meant to define the version of the software to be used elsewhere.
 """
-__version__ = "1.0.7"
+__version__ = "1.1.0"

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -200,11 +200,8 @@ class BatSurvey(BatObservation):
             # (indir), the directory that the results will be saved into (outdir), the imput catalog (incatalog),
             # the detector thresholds (detthresh/detthresh2)
 
-            # need to get the file name off to get the dir this file is located in to get the default survey catalog
-            dir = Path(__file__[::-1].partition("/")[-1][::-1])
-
             # need to determine if there is a pattern_map_directory. If this is None use the ba.datadir() and see if
-            # the direcotry exists. If so, check that the appropriate pattern map exists for the day of observation,
+            # the directory exists. If so, check that the appropriate pattern map exists for the day of observation,
             # if it doesnt then load the pattern map for the day that is closest. If there are no pattern map files
             # at all then dont pass anything into batsurvey for these parameters
 
@@ -291,8 +288,8 @@ class BatSurvey(BatObservation):
                 )
 
                 input_dict_copy["incatalog"] = str(
-                    dir.joinpath("data/survey6b_2.cat")
-                )  # os.path.join(dir,'data/survey6b_2.cat')
+                    Path(__file__).parent.joinpath("data/survey6b_2.cat")
+                )
                 input_dict_copy["detthresh"] = "10000"
                 input_dict_copy["detthresh2"] = "10000"
 
@@ -344,7 +341,7 @@ class BatSurvey(BatObservation):
                     or input_dict_copy["incatalog"] is None
                 ):
                     input_dict_copy["incatalog"] = str(
-                        dir.joinpath("data/survey6b_2.cat")
+                        Path(__file__).parent.joinpath("data/survey6b_2.cat")
                     )
 
                 if (

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -686,9 +686,6 @@ class BatSurvey(BatObservation):
         except AttributeError:
             hsp.utils.local_pfiles(par_dir=str(self._local_pfile_dir))
 
-        # get the current dir
-        current_dir = Path.cwd()
-
         if calc_upper_lim and bkg_nsigma is None:
             raise ValueError(
                 "A value for bkg_nsigma has not been passed to the function to calculate upper limits."

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -1132,7 +1132,8 @@ class BatSurvey(BatObservation):
                         print(
                             "This method does not add up the counts for more than one time intervals."
                         )
-                        sys.exit(0)
+                        raise RuntimeError("Found more than one matched time, please double check the time interval.\n"
+                                           "This method does not add up the counts for more than one time intervals.")
             except FileNotFoundError as e:
                 print(e)
                 raise FileNotFoundError(

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -720,25 +720,25 @@ class BatSurvey(BatObservation):
         # reset the save the pha file names of all pha files if necessary
         if clean_dir:
             self.set_pha_filenames("", reset=True)
-        for id in id_list:
+        for ident in id_list:
             if verbose:
-                print("Creating PHA file for ", id)
+                print("Creating PHA file for ", ident)
 
             # get the proper name for the source incase the user didnt get the name correct
             x = sorted(merge_output_path.glob("*.cat"))
             catalog_sources = [i.stem for i in x]
-            test = self._compare_source_name(id, catalog_sources)
+            test = self._compare_source_name(ident, catalog_sources)
             if np.sum(test) > 0:
-                id = np.array(catalog_sources)[
-                    self._compare_source_name(id, catalog_sources)
+                ident = np.array(catalog_sources)[
+                    self._compare_source_name(ident, catalog_sources)
                 ][0]
             else:
-                id = None
+                ident = None
 
             # get info from the newly created cat file (from merge)
             catalog = merge_output_path.joinpath(
-                f"{id}.cat"
-            )  # os.path.join(os.path.split(self.merge_input['outfile'])[0], id+".cat")
+                f"{ident}.cat"
+            )
             try:
                 cat_file = fits.open(str(catalog))
                 tbdata = cat_file[1].data
@@ -780,7 +780,7 @@ class BatSurvey(BatObservation):
                     if np.size(idx) == 0:
                         raise ValueError(
                             "The pointing ID does not contain an observation of the source:",
-                            id,
+                            ident,
                         )
                     name_array = name_array[idx]
                     raobj_array = raobj_array[idx]
@@ -940,11 +940,11 @@ class BatSurvey(BatObservation):
 
                         if calc_upper_lim:
                             survey_pha_file = output_dir.joinpath(
-                                f"{id}_survey_{pointing_array[i]}_bkgnsigma_{int(bkg_nsigma)}_upperlim.pha"
+                                f"{ident}_survey_{pointing_array[i]}_bkgnsigma_{int(bkg_nsigma)}_upperlim.pha"
                             )
                         else:
                             survey_pha_file = output_dir.joinpath(
-                                f"{id}_survey_{pointing_array[i]}.pha"
+                                f"{ident}_survey_{pointing_array[i]}.pha"
                             )
                         self.set_pha_filenames(survey_pha_file)
                         pha_thdulist.writeto(str(survey_pha_file))
@@ -954,7 +954,7 @@ class BatSurvey(BatObservation):
                         pha_prime_hdr = pha_hdulist[0].header
                         pha_spec_hdr = pha_hdulist[1].header
                         pha_ebound_hdr = pha_hdulist[2].header
-                        pha_gti_hdr = pha_hdulist[3].header
+                        #pha_gti_hdr = pha_hdulist[3].header this header is not currenlty used
 
                         pha_prime_hdr["TELESCOP"] = (
                             "SWIFT",
@@ -1137,7 +1137,7 @@ class BatSurvey(BatObservation):
                 print(e)
                 raise FileNotFoundError(
                     f"This means that the batsurvey script didnt deem there to be good enough statistics for "
-                    + f"source {id} in this observation ID."
+                    + f"source {ident} in this observation ID."
                 )
 
     def load_source_information(self, sources):

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -1614,7 +1614,7 @@ class MosaicBatSurvey(BatSurvey):
             # create dict of mosaic pointings ids and their respective information of time, exposure, etc which is
             # the same for each pointing
             self.pointing_info = dict.fromkeys(self.pointing_ids)
-            for id in self.pointing_ids:
+            for point_id in self.pointing_ids:
                 file = fits.open(
                     str(self.result_dir.joinpath("swiftbat_exposure_c0.img"))
                 )  # os.path.join(mosaic_dir, 'swiftbat_exposure_c0.img'))
@@ -1658,7 +1658,7 @@ class MosaicBatSurvey(BatSurvey):
                     mjd_stop_time=tbin_end_mjdtime,
                 )
 
-                self.pointing_info[id] = dict(
+                self.pointing_info[point_id] = dict(
                     met_time=time_array,
                     exposure=exposure_array,
                     utc_time=utctime,

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -1,6 +1,6 @@
 """
-This file contains the survey class that is inherited from the observation class. this class contains additional information
-about a given survey. it also reads in survey data and processes it
+This file contains the survey class that is inherited from the observation class. this class contains additional
+information about a given survey. it also reads in survey data and processes it
 
 Tyler Parsotan April 5 2023
 """
@@ -67,18 +67,22 @@ class BatSurvey(BatObservation):
         Saves a BatSurvey object
     merge_pointings(input_dict=None, verbose=False):
         Merges the counts from multiple pointings found within an observation ID dataset
-    calculate_pha(id_list=None, output_dir=None, calc_upper_lim=False, bkg_nsigma=None, verbose=True, clean_dir=False, single_pointing=None):
+    calculate_pha(id_list=None, output_dir=None, calc_upper_lim=False, bkg_nsigma=None, verbose=True, clean_dir=False,
+            single_pointing=None):
         Calculates the PHA file for each pointing found within an observation ID dataset
     load_source_information(sources):
-        Loads the count rate, background variance, and snr from the .cat file produced by batsurvey for the sources of interest
+        Loads the count rate, background variance, and snr from the .cat file produced by batsurvey for the sources of
+        interest
     get_pointing_ids():
         Returns the pointing ids in the observation ID
     get_pointing_info(pointing_id, source_id=None)
         Gets the dictionary of information associated with the specified pointing id and source id if specified
     set_pointing_info(pointing_id, key, value, source_id=None)
-        Sets the key/value pair for the dictionary of information associated with the specified pointing id and source, if the source_id is specified
+        Sets the key/value pair for the dictionary of information associated with the specified pointing id and source,
+        if the source_id is specified
     get_pha_filenames(id_list=None, pointing_id_list=None)
-        Gets the pha filename list of the sources supplied in id_list and for the pointing ids supplied by pointing_id_list
+        Gets the pha filename list of the sources supplied in id_list and for the pointing ids supplied by
+        pointing_id_list
     set_pha_filenames(file, reset=False)
         Sets the pha filenames attribute or resets it to be an empty list
     load_source_information(sources)
@@ -101,27 +105,29 @@ class BatSurvey(BatObservation):
         """
         Constructs the BatSurvey object.
 
-        Runs heasoft batsurvey on the observation ID folder. If this calculation was done previouly and the results saved,
-        the user can load the saved state.
+        Runs heasoft batsurvey on the observation ID folder. If this calculation was done previously and the results
+        saved, the user can load the saved state.
 
         :param obs_id: String of the observation ID
-        :param obs_dir: None or String of the location to the folder with the observation ID, defaults to datadir directory
+        :param obs_dir: None or String of the location to the folder with the observation ID, defaults to datadir
+            directory
         :param input_dict: Dictionary of values that will be passed to heasoftpy's batsurvey. The default values are:
                 indir=obs_dir
                 outdir=obs_dir + '_surveyresult'
                 detthresh=10000
                 detthresh2=10000
                 incatalog=survey6b_2.cat (included with BatAnalysis code)
-            Any parameters listed above that are excluded from a dictionary or set to None (not a string, but a python None
-            object) will take on these values.
-            A dictionary can take the form x=dict(incatalog="custom_catalog.cat", detthresh="10000"). Here, the remaining
-            unspecified parameters will first take the values above and then the default values of heasoft's batsurvey.
+            Any parameters listed above that are excluded from a dictionary or set to None (not a string, but a python
+            None object) will take on these values.
+            A dictionary can take the form x=dict(incatalog="custom_catalog.cat", detthresh="10000"). Here, the
+            remaining unspecified parameters will first take the values above and then the default values of
+            heasoft's batsurvey.
         :param recalc: Boolean to either delete the existing batsurvey results and start over
         :param verbose: Boolean to print diagnostic information
         :param load_dir: String of the directory that holds the result directory of batsurvey for a given observation ID
-        :param patt_noise_dir: String of the directory that holds the pre-calculated pattern noise maps for BAT. None defaults to
-            looking for the maps in a folder called: "noise_pattern_maps" located in the ba.datadir() directory. If this directory
-            doesn't exist then pattern maps are not used.
+        :param patt_noise_dir: String of the directory that holds the pre-calculated pattern noise maps for BAT.
+            None defaults to looking for the maps in a folder called: "noise_pattern_maps" located in the ba.datadir()
+            directory. If this directory doesn't exist then pattern maps are not used.
         """
 
         # Set default energy ranges in keV and system errors
@@ -140,20 +146,20 @@ class BatSurvey(BatObservation):
         # initialize super class
         super().__init__(obs_id, obs_dir)
 
-        # See if a loadfile exists, if we dont want to recalcualte everything, otherwise remove any load file and
+        # See if a loadfile exists, if we dont want to recalculate everything, otherwise remove any load file and
         # .batsurveycomplete file (this is produced only if the batsurvey calculation was completely finished, and thus
         # know that we can safely load the batsurvey.pickle file)
         if not recalc and load_dir is None:
             load_dir = sorted(self.obs_dir.parent.glob(obs_id + "_survey*"))
 
-            # see if there are any _surveyresult dir or anything otherwise just use obs_dir as a place holder
+            # see if there are any _surveyresult dir or anything otherwise just use obs_dir as a placeholder
             if len(load_dir) > 0:
                 load_dir = load_dir[0]
             else:
                 load_dir = self.obs_dir
         elif not recalc and load_dir is not None:
             load_dir_test = sorted(Path(load_dir).glob(obs_id + "_survey*"))
-            # see if there are any _surveyresult dir or anything otherwise just use load_dir as a place holder
+            # see if there are any _surveyresult dir or anything otherwise just use load_dir as a placeholder
             if len(load_dir_test) > 0:
                 load_dir = load_dir_test[0]
             else:
@@ -176,11 +182,10 @@ class BatSurvey(BatObservation):
 
         # if load_file is None:
         # if the user wants to recalculate things or if there is no batsurvey.pickle file, or if there is no
-        # .batsurvey_complete file (meaning that the __init__ method didnt complete)
+        # .batsurvey_complete file (meaning that the __init__ method didn't complete)
         if recalc or not load_file.exists() or not complete_file.exists():
-            # batsurvey relies on "bat" and "auxil" folders in the observation ID folder, therefore we need to check for these
-            # https://heasarc.gsfc.nasa.gov/ftools/caldb/help/batsurvey.html
-            # if not os.path.isdir(os.path.join(self.obs_dir,"bat")) or not os.path.isdir(os.path.join(self.obs_dir,"auxil")):
+            # batsurvey relies on "bat" and "auxil" folders in the observation ID folder, therefore we need to check
+            # for these https://heasarc.gsfc.nasa.gov/ftools/caldb/help/batsurvey.html
             if (
                 not self.obs_dir.joinpath("bat").joinpath("survey").is_dir()
                 or not self.obs_dir.joinpath("auxil").is_dir()
@@ -190,18 +195,18 @@ class BatSurvey(BatObservation):
                     + "analyze BAT survey data. One or both of these folders are missing."
                 )
 
-            # can do hsp.batsurvey? in ipython to see what the default parameters are
-            # if the input directory is None, the user wants the default parameters and also wants the below specified default
-            # observation directory (indir), the directory that the results will be saved into (outdir), the imput catalog
-            # (incatalog), the detector thresholds (detthresh/detthresh2)
+            # can do hsp.batsurvey? in ipython to see what the default parameters are if the input directory is None,
+            # the user wants the default parameters and also wants the below specified default observation directory
+            # (indir), the directory that the results will be saved into (outdir), the imput catalog (incatalog),
+            # the detector thresholds (detthresh/detthresh2)
 
             # need to get the file name off to get the dir this file is located in to get the default survey catalog
             dir = Path(__file__[::-1].partition("/")[-1][::-1])
 
-            # need to determine if there is a pattern_map_directory. If this is None use the ba.datadir() and see if the
-            # direcotry exists. If so, check that the appropriate pattern map exists for the day of observation, if it doesnt
-            # then load the pattern map for the day that is closest.
-            # If there are no pattern map files at all then dont pass anything into batsurvey for these parameters
+            # need to determine if there is a pattern_map_directory. If this is None use the ba.datadir() and see if
+            # the direcotry exists. If so, check that the appropriate pattern map exists for the day of observation,
+            # if it doesnt then load the pattern map for the day that is closest. If there are no pattern map files
+            # at all then dont pass anything into batsurvey for these parameters
 
             if patt_noise_dir is None:
                 patt_noise_dir = datadir().joinpath("noise_pattern_maps")
@@ -209,8 +214,8 @@ class BatSurvey(BatObservation):
                 # make a Path object
                 patt_noise_dir = Path(patt_noise_dir)
 
-            # read in the header of a file in the survey observation ID directory to get the MET start time and convert to
-            # year/day of year
+            # read in the header of a file in the survey observation ID directory to get the MET start time and
+            # convert to year/day of year
             input_file = sorted(
                 self.obs_dir.joinpath("bat").joinpath("survey").glob("*")
             )[0]
@@ -298,8 +303,8 @@ class BatSurvey(BatObservation):
             else:
                 # need to create copy of input dict so we dont overwrite it
                 input_dict_copy = input_dict.copy()
-                # see if the user wanted the indir and outdir to be the defaults presented above, even though they specify
-                # other preferences to the call to batsurvey
+                # see if the user wanted the indir and outdir to be the defaults presented above, even though they
+                # specify other preferences to the call to batsurvey
                 if "indir" not in input_dict_copy or input_dict_copy["indir"] is None:
                     input_dict_copy["indir"] = str(self.obs_dir)
                 else:
@@ -312,7 +317,7 @@ class BatSurvey(BatObservation):
                 if "outdir" not in input_dict_copy or input_dict_copy["outdir"] is None:
                     input_dict_copy["outdir"] = str(
                         self.obs_dir.parent / f"{self.obs_dir.name}_surveyresult"
-                    )  # self.obs_dir + '_surveyresult'
+                    )
                 else:
                     # make this a fully resolved path
                     if not Path(input_dict_copy["outdir"]).is_absolute():
@@ -320,7 +325,8 @@ class BatSurvey(BatObservation):
                             Path.cwd().joinpath(input_dict_copy["outdir"])
                         )
 
-                # if detthresh/detthresh2 isnt defined need to set default detthresh to prevent gti identification errors
+                # if detthresh/detthresh2 isnt defined need to set default detthresh to prevent gti identification
+                # errors
                 if (
                     "detthresh" not in input_dict_copy
                     or input_dict_copy["detthresh"] is None
@@ -339,7 +345,7 @@ class BatSurvey(BatObservation):
                 ):
                     input_dict_copy["incatalog"] = str(
                         dir.joinpath("data/survey6b_2.cat")
-                    )  # os.path.join(dir, 'data/survey6b_2.cat')
+                    )
 
                 if (
                     "global_pattern_map" not in input_dict_copy
@@ -366,7 +372,6 @@ class BatSurvey(BatObservation):
                     input_dict_copy["cleanexpr"] = "ALWAYS_CLEAN==T"
 
                 # make sure that the output directory exists
-                # if not os.path.isdir(os.path.split(input_dict_copy['outdir'])[0]) and len(os.path.split(input_dict_copy['outdir'])[0])>0:
                 if not Path(input_dict_copy["outdir"]).parent.exists():
                     raise ValueError(
                         "The directory %s needs to exist for batsurvey to save its results."
@@ -387,7 +392,6 @@ class BatSurvey(BatObservation):
 
             # if the user wants to relaculate things or if recalc==False but the result directory specified doesnt exist
             # we need to recalculate things for further processing, IMPLEMENT LATER ON
-            # if recalc or os.path.isdir(self.result_dir):
             # call the heasoftpy command
             bs = self._call_batsurvey(input_dict_copy)
             self.batsurvey_result = bs
@@ -406,7 +410,7 @@ class BatSurvey(BatObservation):
             complete_file = self.result_dir.joinpath(".batsurvey_complete")
 
             # identify the pointings that have been created
-            # all these pointings may not have the object of interest, so need to double check that with the
+            # all these pointings may not have the object of interest, so need to double-check that with the
             # merge_pointings method
             self.pointing_flux_files = sorted(
                 self.result_dir.glob(f"point*/*_{bs.params['ncleaniter']}.cat")
@@ -417,11 +421,12 @@ class BatSurvey(BatObservation):
             for pointing in self.pointing_flux_files:
                 self.pointing_ids.append(
                     pointing.parent.name.split("_")[-1]
-                )  # os.path.split(pointing)[0].split('_')[-1])
+                )
 
-            # create dict of pointings ids and their respective information of time, exposure, etc which si the same for each pointing
+            # create dict of pointings ids and their respective information of time, exposure, etc which is the same
+            # for each pointing
             self.pointing_info = dict.fromkeys(self.pointing_ids)
-            for pointing, id in zip(self.pointing_flux_files, self.pointing_ids):
+            for pointing, ident in zip(self.pointing_flux_files, self.pointing_ids):
                 lc_fits = fits.open(pointing)
                 lc_fits_data = lc_fits[1].data
 
@@ -435,10 +440,10 @@ class BatSurvey(BatObservation):
                 lc_fits.close()
 
                 # open the status file to save the success code
-                status_file = pointing.parent.joinpath(f"point_{id}_status.txt")
+                status_file = pointing.parent.joinpath(f"point_{ident}_status.txt")
                 stat = self._batsurvey_error(status_file)[0]
 
-                self.pointing_info[id] = dict(
+                self.pointing_info[ident] = dict(
                     success=stat,
                     fail_code=None,
                     met_time=time_array,
@@ -450,8 +455,8 @@ class BatSurvey(BatObservation):
             # see if there were any pointings that failed
             status_file = self.result_dir.joinpath("stats_point.dat")
 
-            # somethimes this file may not exist if batsurvey determines that there are no GTIs at all
-            # in this case there will be no pointing flux files so we will execure the if statement a little later on
+            # sometimes this file may not exist if batsurvey determines that there are no GTIs at all
+            # in this case there will be no pointing flux files so we will execute the if statement a little later on
             if status_file.exists():
                 with open(status_file, "r") as f:
                     batsurvey_output = f.readlines()
@@ -503,8 +508,6 @@ class BatSurvey(BatObservation):
                     f"The results for each pointing of observation ID {self.obs_id} is:\n {' '.join(batsurvey_output)}"
                 )
 
-            # self.survey_input=input_dict_copy
-
         else:
             load_file = Path(load_file).expanduser().resolve()
             self.load(load_file)
@@ -533,7 +536,7 @@ class BatSurvey(BatObservation):
         """
         file = self.result_dir.joinpath(
             "batsurvey.pickle"
-        )  # os.path.join(self.result_dir, "batsurvey.pickle")
+        )
         with open(file, "wb") as f:
             pickle.dump(self.__dict__, f, 2)
         print("A save file has been written to %s." % (str(file)))
@@ -553,14 +556,7 @@ class BatSurvey(BatObservation):
 
         # directly calls batsurvey
         try:
-            # task = hsp.HSPTask('batsurvey')
-            # result = task(**input_dict)
-            # return result
-
-            # print(os.getenv("PFILES"))
-
             return hsp.batsurvey(**input_dict)
-
         except Exception:
             # see if there were any pointings that failed
             status_file = self.result_dir.joinpath("stats_point.dat")
@@ -581,7 +577,6 @@ class BatSurvey(BatObservation):
             associated reason for failure
         """
 
-        # status_file = pointing.name.joinpath(f"point_{id}_status.txt")
         with open(status_file, "r") as f:
             output = f.readlines()[0]
         stat = output.split(";")[0].split("status=")[-1]
@@ -615,10 +610,6 @@ class BatSurvey(BatObservation):
         # calls batsurvey_catmux to merge pointings, outputs to the survey result directory
         # there is a bug in the heasoftpy code so try to explicitly call it for now
         return hsp.batsurvey_catmux(**input_dict)
-        # input_string="batsurvey-catmux "
-        # for i in input_dict:
-        #    input_string=input_string+"%s=%s " % (i, input_dict[i])
-        # os.system(input_string)
 
     def merge_pointings(self, input_dict=None, verbose=False):
         """
@@ -632,7 +623,7 @@ class BatSurvey(BatObservation):
         if input_dict is None or "outfile" not in input_dict:
             output_dir = self.result_dir.joinpath(
                 "merged_pointings_lc"
-            )  # os.path.join(self.result_dir, 'merged_pointings_lc')
+            )
         else:
             output_dir = (
                 Path(input_dict["outfile"]).expanduser().resolve()
@@ -653,7 +644,7 @@ class BatSurvey(BatObservation):
                     keycolumn="NAME",
                     infile=str(i),
                     outfile=str(output_dir.joinpath("%s.cat")),
-                )  # os.path.join(output_dir,"%s.cat"))
+                )
             else:
                 dictionary = input_dict.copy()
                 dictionary["infile"] = str(i)
@@ -710,13 +701,13 @@ class BatSurvey(BatObservation):
             # set default directory to save files into
             output_dir = self.result_dir.joinpath(
                 "PHA_files"
-            )  # os.path.join(self.result_dir, "PHA_files")
+            )
         else:
             output_dir = Path(output_dir).expanduser().resolve()
 
         if not calc_upper_lim:
             # see if directory exists, if no create of so then delete and recreate
-            # if we are calucalting the upper limit, the directory already exists
+            # if we are calculating the upper limit, the directory already exists
             dirtest(output_dir, clean_dir=clean_dir)
 
         merge_output_path = Path(self.merge_input["outfile"]).parent
@@ -728,8 +719,6 @@ class BatSurvey(BatObservation):
                 id_list = [id_list]
         else:
             # use the ids from the *.cat files produced, these are ones that have been identified in the survey obs_id
-            # x = glob.glob(os.path.join(os.path.split(self.merge_input['outfile'])[0],'*.cat'))
-            # id_list=[os.path.basename(i).split('.cat')[0] for i in x]
             x = sorted(merge_output_path.glob("*.cat"))
             id_list = [i.stem for i in x]
 
@@ -764,7 +753,7 @@ class BatSurvey(BatObservation):
                 decobj_array = tbdata.field("DEC_OBJ")
                 time_array = tbdata.field("TIME")
                 tstart_sinceT0 = np.zeros_like(time_array)  # need to understand this
-                timestop_array = tbdata.field("TIME_STOP")
+                #timestop_array = tbdata.field("TIME_STOP") #this isnt used
                 exposure_array = tbdata.field("EXPOSURE")
                 ffapp_array = tbdata.field("FFAPP")
                 pcodeapp_array = tbdata.field("PCODEAPP")
@@ -789,8 +778,8 @@ class BatSurvey(BatObservation):
                 phi_array = tbdata.field("PHI")
                 cat_file.close()
 
-                # if we want to calculate or recalculate pha for certain pointings we modify the arrays to just the values
-                # of interest
+                # if we want to calculate or recalculate pha for certain pointings we modify the arrays to just the
+                # values of interest
                 if single_pointing is not None:
                     # expect a pointing ID which we will match up to the pointing_array
                     idx = np.where("point_" + single_pointing == pointing_array)[0]
@@ -804,7 +793,7 @@ class BatSurvey(BatObservation):
                     decobj_array = decobj_array[idx]
                     time_array = time_array[idx]
                     tstart_sinceT0 = tstart_sinceT0[idx]  # need to understand this
-                    timestop_array = timestop_array[idx]
+                    #timestop_array = timestop_array[idx] #this isnt used
                     exposure_array = exposure_array[idx]
                     ffapp_array = ffapp_array[idx]
                     pcodeapp_array = pcodeapp_array[idx]
@@ -817,13 +806,6 @@ class BatSurvey(BatObservation):
                     theta_array = theta_array[idx]
                     phi_array = phi_array[idx]
 
-                # count_rate_band = []
-                # count_rate_band_error = []
-                # channel = []
-                # gti_starttime = []
-                # gti_stoptime = []
-
-                # check = 0
                 # make pha file at the specified times
                 # Looping over different pointings for a given observation.
                 for i in range(len(time_array)):
@@ -861,7 +843,6 @@ class BatSurvey(BatObservation):
                         ).joinpath(
                             f"{pointing_array[i]}_{self.batsurvey_result.params['ncleaniter']}.cat"
                         )
-                        # os.path.join(self.result_dir, pointing_array[i], f"{pointing_array[i]}_{self.batsurvey_result.params['ncleaniter']}.cat")
 
                         org_cat_file = fits.open(str(org_catfile_name))
                         org_cat_data = org_cat_file[1].data
@@ -874,20 +855,20 @@ class BatSurvey(BatObservation):
                             f"{pointing_array[i]}"
                         ).joinpath(
                             f"{pointing_array[i]}.att"
-                        )  # os.path.join(self.result_dir, pointing_array[i], pointing_array[i]+'.att')
+                        )
                         dpifile = self.result_dir.joinpath(
                             f"{pointing_array[i]}"
                         ).joinpath(
                             f"{pointing_array[i]}_1.dpi"
-                        )  # os.path.join(self.result_dir, pointing_array[i], pointing_array[i]+ '_1.dpi')
+                        )
                         detmask = self.result_dir.joinpath(
                             f"{pointing_array[i]}"
                         ).joinpath(
                             f"{pointing_array[i]}.detmask"
-                        )  # os.path.join(self.result_dir, pointing_array[i], pointing_array[i]+ '.detmask')
+                        )
                         output_srcmask = output_dir.joinpath(
                             "src.mask"
-                        )  # os.path.join(output_dir, 'src.mask')
+                        )
 
                         input_dict = dict(
                             outfile=str(output_srcmask),
@@ -901,24 +882,10 @@ class BatSurvey(BatObservation):
 
                         result = hsp.batmaskwtimg(**input_dict)
 
-                        # mskwtsqf = subprocess.getoutput("fkeyprint %s MSKWTSQF | tail -1 | awk '{print $2}'" % (output_srcmask))
-
-                        # go into the directory to run fkeyprint
-                        # if str(output_dir) != str(current_dir):
-                        #    os.chdir(output_dir)
-
-                        # test = hsp.fkeyprint(infile=str(output_srcmask.name), keynam="MSKWTSQF")
-                        # mskwtsqf=re.findall("\d+\.\d+", test.output[-2])[0]
-
-                        # cd back
-                        # if str(output_dir) != str(current_dir):
-                        #    os.chdir(current_dir)
                         with fits.open(str(output_srcmask)) as file:
                             mskwtsqf = file[0].header["MSKWTSQF"]
 
-                        # stop
-
-                        # write count_rate in each band to an pha file
+                        # write count_rate in each band to a pha file
                         spec_col1 = fits.Column(
                             name="CHANNEL", format="J", array=channel
                         )
@@ -978,12 +945,10 @@ class BatSurvey(BatObservation):
                         )
 
                         if calc_upper_lim:
-                            # survey_pha_file = os.path.join(output_dir, id + '_survey_' + pointing_array[i] +'_bkgnsigma_%d'%(bkg_nsigma) + '_upperlim.pha')
                             survey_pha_file = output_dir.joinpath(
                                 f"{id}_survey_{pointing_array[i]}_bkgnsigma_{int(bkg_nsigma)}_upperlim.pha"
                             )
                         else:
-                            # survey_pha_file= os.path.join(output_dir, id + '_survey_' + pointing_array[i] + '.pha')
                             survey_pha_file = output_dir.joinpath(
                                 f"{id}_survey_{pointing_array[i]}.pha"
                             )
@@ -1212,11 +1177,11 @@ class BatSurvey(BatObservation):
                         # get the index of the proper source name in the catalog
                         idx = np.arange(len(pointing_file_sources))[
                             self._compare_source_name(s, pointing_file_sources)
-                        ]  # np.where(s==pointing_file_sources)[0]
+                        ]
 
                         if len(idx) != 0:
-                            # then there is a row for the source of interest so we can read in the data and do the necessary
-                            # calculations
+                            # then there is a row for the source of interest so we can read in the data and do the
+                            # necessary calculations
 
                             # read in the cent rate, the error, etc and save it
                             rate_array = file[1].data[idx]["CENT_RATE"][0]
@@ -1234,18 +1199,8 @@ class BatSurvey(BatObservation):
                             self.set_pointing_info(id, "snr", snr_array, source_id=s)
 
                             # this does the calculation for the total energy range so set the if statement so the
-                            # mosaic results dont attempt to calcualte a wrong energy integrated count rate
+                            # mosaic results dont attempt to calculate a wrong energy integrated count rate
                             if len(rate_array) == 8:
-                                # rate_tot = 0.0
-                                # rate_err_2_tot = 0.0
-                                # bkg_var_2_tot = 0.0
-                                # for j in range(len(rate_array)):
-                                #    rate_num = rate_array[j]
-                                #    rate_err_2 = rate_err_array[j] * rate_err_array[j]
-                                #    bkg_var_2 = bkg_var_array[j] * bkg_var_array[j]
-                                #    rate_tot = rate_tot + rate_num
-                                #    rate_err_2_tot = rate_err_2_tot + rate_err_2
-                                #    bkg_var_2_tot = bkg_var_2_tot + bkg_var_2
                                 energy_idx = np.arange(len(rate_array))
                                 (
                                     rate_tot,
@@ -1256,17 +1211,12 @@ class BatSurvey(BatObservation):
                                 rate_array = np.concatenate(
                                     (self.pointing_info[id][s]["rate"], [rate_tot])
                                 )
-                                # rate_err_tot = np.sqrt(rate_err_2_tot) not needed with method above
-                                # rate_err_array.append(rate_err_tot)
                                 rate_err_array = np.concatenate(
                                     (
                                         self.pointing_info[id][s]["rate_err"],
                                         [rate_err_2_tot],
                                     )
                                 )
-                                # snr_allband_num = rate_tot / np.sqrt(bkg_var_2_tot) not needed with method above
-                                # snr_array.append(snr_allband_num)
-                                # bkg_var_array.append(np.sqrt(bkg_var_2_tot))
                                 snr_array = np.concatenate(
                                     (
                                         self.pointing_info[id][s]["snr"],
@@ -1290,12 +1240,16 @@ class BatSurvey(BatObservation):
                         else:
                             # a given pointing may not have the source in it so just raise a warning
                             try:
-                                warn_str = f"Observation ID: {self.obs_id} Pointing ID: {id} \nThere is no source {s} found in the catalog file. Please double check the spelling.\nThis source may also not be detected in this observation ID/pointing ID"
+                                warn_str = (f"Observation ID: {self.obs_id} Pointing ID: {id} \nThere is no source {s} "
+                                            f"found in the catalog file. Please double check the spelling.\nThis "
+                                            f"source may also not be detected in this observation ID/pointing ID")
                                 warnings.warn(warn_str)
                             except AttributeError:
                                 warn_str = (
-                                    f"Mosaic from {self.pointing_info['mosaic']['user_timebin']['utc_time']}-{self.pointing_info['mosaic']['user_timebin']['utc_stop_time']}"
-                                    f"\nThere is no source {s} found in the catalog file. Please double check the spelling."
+                                    f"Mosaic from {self.pointing_info['mosaic']['user_timebin']['utc_time']}-"
+                                    f"{self.pointing_info['mosaic']['user_timebin']['utc_stop_time']}"
+                                    f"\nThere is no source {s} found in the catalog file. Please double check "
+                                    f"the spelling."
                                     f"\nThis source may also not be detected in this observation ID/pointing ID"
                                 )
                                 warnings.warn(warn_str)
@@ -1363,9 +1317,11 @@ class BatSurvey(BatObservation):
         """
         Gets the pha filenames for the sources identified in id_list
 
-        :param id_list: None, single string, or list of strings of catalog sources that the user wants to get the pha filenames of
-        :param pointing_id_list: None, single string, or list of pointing IDs that the user wants to get the PHA filenames of
-        :param getupperlim: Boolean to specify if the function should return just the upper limit PHA files. Defaut is
+        :param id_list: None, single string, or list of strings of catalog sources that the user wants to get the pha
+            filenames of
+        :param pointing_id_list: None, single string, or list of pointing IDs that the user wants to get the PHA
+            filenames of
+        :param getupperlim: Boolean to specify if the function should return just the upper limit PHA files. Default is
             False, meaning that both normal and upperlimit PHA files will be returned
         :return: returns a list of the pha filenames
         """
@@ -1402,7 +1358,6 @@ class BatSurvey(BatObservation):
         else:
             # only get the pha filenames for the sources identified in id_list taking into account the real source name
             # that is specified in the BatSurvey dictionary which may be a different format than the pha file name
-            # val=[i for i in self.pha_file_names_list if any(str(i) for j in id_list if j in str(i))]
             val = [
                 i
                 for i in self.pha_file_names_list
@@ -1469,18 +1424,7 @@ class BatSurvey(BatObservation):
                 energy_index = np.array([energy_index])
 
         if len(energy_index) > 1:
-            # rate_tot = 0.0
-            # rate_err_2_tot = 0.0
-            # bkg_var_2_tot = 0.0
-            # for j in energy_index:
-            #    rate_num = rate_array[j]
-            #    rate_err_2 = rate_err_array[j] * rate_err_array[j]
-            #    bkg_var_2 = bkg_var_array[j] * bkg_var_array[j]
-            #    rate_tot = rate_tot + rate_num
-            #    rate_err_2_tot = rate_err_2_tot + rate_err_2
-            #    bkg_var_2_tot = bkg_var_2_tot + bkg_var_2
-
-            # the above loop can be vectorized with numpy
+            # vectorized with numpy
             rate_tot = np.sum(rate_array[energy_index])
             rate_err_2_tot = np.sum(rate_err_array[energy_index] ** 2)
             bkg_var_2_tot = np.sum(bkg_var_array[energy_index] ** 2)
@@ -1498,7 +1442,7 @@ class BatSurvey(BatObservation):
     def _compare_source_name(self, string_1, string_2):
         """
         This compares 2 strings that can be either the user supplied source ID or the source ID from a catalog and
-        identifies if they are the same. This removes any non alpha-numeric values(except dots) in each string and compares them.
+        identifies if they are the same. This removes any non alphanumeric values(except dots) in each string and compares them.
 
         :param string_1: string
         :param string_2: string or array of strings
@@ -1530,9 +1474,9 @@ class BatSurvey(BatObservation):
 
     def get_real_source_name(self, pointing_id, source):
         """
-        This method deermines the real source name in the pointing ID's dictionary. This can be something that was passed
-        in before when loading in calculated rate data or the name of a PHA file with the source name. This mehtod matches
-        these two formats so all the info related to a given source is saved appropriately.
+        This method deermines the real source name in the pointing ID's dictionary. This can be something that was
+        passed in before when loading in calculated rate data or the name of a PHA file with the source name.
+        This method matches these two formats so all the info related to a given source is saved appropriately.
 
         :param pointing_id: string of the pointing ID of interest
         :param source: string of the
@@ -1592,18 +1536,22 @@ class MosaicBatSurvey(BatSurvey):
         Saves a MosaicBatSurvey object
     merge_pointings(input_dict=None, verbose=False):
         Merges the counts from multiple pointings found within an observation ID dataset
-    calculate_pha(id_list=None, output_dir=None, calc_upper_lim=False, bkg_nsigma=None, verbose=True, clean_dir=False, single_pointing=None):
+    calculate_pha(id_list=None, output_dir=None, calc_upper_lim=False, bkg_nsigma=None, verbose=True, clean_dir=False,
+            single_pointing=None):
         Calculates the PHA file for each source found in the mosaic image
     load_source_information(sources):
-        Loads the count rate, background variance, and snr from the .cat file produced by batcelldetect for the sources of interest
+        Loads the count rate, background variance, and snr from the .cat file produced by batcelldetect for the sources
+        of interest
     get_pointing_ids():
         Returns the pointing ids in the observation ID
     get_pointing_info(pointing_id, source_id=None)
         Gets the dictionary of information associated with the specified pointing id and source id if specified
     set_pointing_info(pointing_id, key, value, source_id=None)
-        Sets the key/value pair for the dictionary of information associated with the specified pointing id and source, if the source_id is specified
+        Sets the key/value pair for the dictionary of information associated with the specified pointing id and source,
+        if the source_id is specified
     get_pha_filenames(id_list=None, pointing_id_list=None)
-        Gets the pha filename list of the sources supplied in id_list and for the pointing ids supplied by pointing_id_list
+        Gets the pha filename list of the sources supplied in id_list and for the pointing ids supplied by
+        pointing_id_list
     set_pha_filenames(file, reset=False)
         Sets the pha filenames attribute or resets it to be an empty list
     load_source_information(sources)
@@ -1621,7 +1569,7 @@ class MosaicBatSurvey(BatSurvey):
 
         :param mosaic_dir: path object to the location of the mosaiced images that were calculated
         :param recalc: Boolean default False, which indicates that the method should try to load data from a file in
-            the mosaic_dir directory. True means that the load file will be ignored and attributes will be re-obtaiend
+            the mosaic_dir directory. True means that the load file will be ignored and attributes will be re-obtained
             for the object.
         """
 
@@ -1652,8 +1600,8 @@ class MosaicBatSurvey(BatSurvey):
         # .batsurveycomplete file (this is produced only if the batsurvey calculation was completely finished, and thus
         # know that we can safely load the batsurvey.pickle file)
         if not load_file.exists() or recalc:
-            # can have a mosaic directory with no mosaic-ed images since there would be no survey observations in the time
-            # bin. In this case throw an error
+            # can have a mosaic directory with no mosaic-ed images since there would be no survey observations in the
+            # time bin. In this case throw an error
             if not self.result_dir.joinpath("swiftbat_exposure_c0.img").exists():
                 raise ValueError("This mosaic time bin is invalid.")
 
@@ -1666,8 +1614,8 @@ class MosaicBatSurvey(BatSurvey):
             # need to set the mosaic pointing ID
             self.pointing_ids = ["mosaic"]
 
-            # create dict of mosaic pointings ids and their respective information of time, exposure, etc which si the same
-            # for each pointing
+            # create dict of mosaic pointings ids and their respective information of time, exposure, etc which is
+            # the same for each pointing
             self.pointing_info = dict.fromkeys(self.pointing_ids)
             for id in self.pointing_ids:
                 file = fits.open(
@@ -1691,7 +1639,6 @@ class MosaicBatSurvey(BatSurvey):
                 mjdtime_stop = met2mjd(time_array_stop)
                 utctime_stop = met2utc(time_array_stop, mjd_time=mjdtime_stop)
 
-                # with fits.open(outventory_file) as file:
                 tbin_start_met = file_header["S_TBIN"]
                 tbin_end_met = file_header["E_TBIN"]
 
@@ -1774,16 +1721,14 @@ class MosaicBatSurvey(BatSurvey):
 
         resulting_files = ""
         for num in range(self.nfacets):
-            # file=os.path.join(self.result_dir,f'swiftbat_flux_c{num}.img')
-            # pcodefile=os.path.join(self.result_dir,f'swiftbat_exposure_c{num}.img')
-            # outfile=os.path.join(self.result_dir,f'sources_c{num}.cat')
             file = self.result_dir.joinpath(f"swiftbat_flux_c{num}.img")
             pcodefile = self.result_dir.joinpath(f"swiftbat_exposure_c{num}.img")
             outfile = self.result_dir.joinpath(f"sources_c{num}.cat")
 
             default_input_dict = dict(
                 infile=f"{file}",
-                # [col #HDUCLAS2 = "NET"; #FACET = {num}]', #This isnt needed since this info is in HDUCLAS2 and BSKYPLAN already
+                # [col #HDUCLAS2 = "NET"; #FACET = {num}]', #This isnt needed since this info is in HDUCLAS2 and
+                # BSKYPLAN already
                 outfile=str(outfile),
                 snrthresh=4.0,
                 psfshape="GAUSSIAN",
@@ -1907,13 +1852,13 @@ class MosaicBatSurvey(BatSurvey):
             # set default directory to save files into
             output_dir = self.result_dir.joinpath(
                 "PHA_files"
-            )  # os.path.join(self.result_dir, "PHA_files")
+            )
         else:
             output_dir = Path(output_dir).expanduser().resolve()
 
         if not calc_upper_lim:
             # see if directory exists, if no create of so then delete and recreate
-            # if we are calucalting the upper limit, the directory already exists
+            # if we are calculating the upper limit, the directory already exists
             dirtest(output_dir, clean_dir=clean_dir)
 
         merge_output_path = Path(self.merge_input["outfile"]).parent
@@ -1925,8 +1870,6 @@ class MosaicBatSurvey(BatSurvey):
                 id_list = [id_list]
         else:
             # use the ids from the *.cat files produced, these are ones that have been identified in the survey obs_id
-            # x = glob.glob(os.path.join(os.path.split(self.merge_input['outfile'])[0],'*.cat'))
-            # id_list=[os.path.basename(i).split('.cat')[0] for i in x]
             x = sorted(merge_output_path.glob("*.cat"))
             id_list = [i.stem for i in x]
 
@@ -1935,9 +1878,8 @@ class MosaicBatSurvey(BatSurvey):
         if clean_dir:
             self.set_pha_filenames("", reset=True)
 
-        # need to put the repsonse file in the directory since the filename with the full path can be way to long to fit in the pha file
-        # and be read in by xspec, or can try doing a symbolic link
-        # responsefile=os.path.join(os.path.split(__file__)[0], 'data', 'swiftbat_survey_full_157m.rsp')
+        # need to put the repsonse file in the directory since the filename with the full path can be way to long to
+        # fit in the pha file and be read in by xspec, or can try doing a symbolic link responsefile=os.path.join(
         responsefile = (
             Path(__file__)
             .parent.joinpath("data")
@@ -1945,10 +1887,9 @@ class MosaicBatSurvey(BatSurvey):
         )
         copied_responsefile = output_dir.joinpath(
             responsefile.name
-        )  # os.path.join(output_dir, responsefilename)
+        )
         # if the file doesnt exist in the directory create a sym link to the file
-        if not copied_responsefile.exists():  # os.path.lexists(copied_responsefile):
-            # os.symlink(responsefile, copied_responsefile)
+        if not copied_responsefile.exists():
             copied_responsefile.symlink_to(responsefile)
 
         for id in id_list:
@@ -1970,7 +1911,7 @@ class MosaicBatSurvey(BatSurvey):
             try:
                 catalog = merge_output_path.joinpath(
                     f"{id}.cat"
-                )  # os.path.join(os.path.split(self.merge_input['outfile'])[0], id+".cat")
+                )
                 cat_file = fits.open(catalog)
                 tbdata = cat_file[1].data
                 name_array = tbdata.field("NAME")
@@ -1992,7 +1933,6 @@ class MosaicBatSurvey(BatSurvey):
 
                 cat_file.close()
 
-                # check = 0
                 # make pha file
                 # write count_rate in each band to an pha file, exclude the 14-195 count
                 spec_col1 = fits.Column(name="CHANNEL", format="I", array=self.channel)
@@ -2033,13 +1973,11 @@ class MosaicBatSurvey(BatSurvey):
                 pha_thdulist = fits.HDUList([pha_primary, spec_tbhdu, ebound_tbhdu])
 
                 if calc_upper_lim:
-                    # survey_pha_file = os.path.join(output_dir, id + '_mosaic_bkgnsigma_%d'%(bkg_nsigma) + '_upperlim.pha')
                     survey_pha_file = output_dir.joinpath(
                         f"{id}_mosaic_bkgnsigma_{int(bkg_nsigma)}_upperlim.pha"
                     )
 
                 else:
-                    # survey_pha_file= os.path.join(output_dir, id + '_mosaic.pha')
                     survey_pha_file = output_dir.joinpath(f"{id}_mosaic.pha")
                 self.set_pha_filenames(survey_pha_file)
                 pha_thdulist.writeto(str(survey_pha_file))
@@ -2078,7 +2016,6 @@ class MosaicBatSurvey(BatSurvey):
                 pha_spec_hdr["CORRSCAL"] = (1.0, "Correction scale factor")
                 pha_spec_hdr["BACKFILE"] = ("none", "Background FITS file")
                 pha_spec_hdr["CORRFILE"] = ("none", "Correction FITS file")
-                # pha_spec_hdr['RESPFILE'] = ('swiftbat_survey_full.rsp', "Redistribution Matrix file (RMF)")
                 pha_spec_hdr["RESPFILE"] = (
                     responsefile.name,
                     "Redistribution Matrix file (RMF)",

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -802,9 +802,11 @@ class BatSurvey(BatObservation):
                 # make pha file at the specified times
                 # Looping over different pointings for a given observation.
                 for i in range(len(time_array)):
+                    # These are to ensure that we are starting fresh with our T_start and T_stop, and not
+                    # appending them.
                     count_rate_band = (
                         []
-                    )  # These are to ensure that we are starting fresh with our T_start and T_stop, and not appending them.
+                    )
                     count_rate_band_error = []
                     channel = []
                     gti_starttime = []
@@ -1155,7 +1157,7 @@ class BatSurvey(BatObservation):
 
         # get the pointing flux files and the pointing ID, these arrays hsould be ordered with respect to one another
         # see for loop in init() to get the pointing IDs
-        for pointing_file, id in zip(self.pointing_flux_files, self.pointing_ids):
+        for pointing_file, point_id in zip(self.pointing_flux_files, self.pointing_ids):
             # make sure that the file exists
             if pointing_file.exists():
                 # then read in the info and try to find where the object is within it if it exists there
@@ -1183,14 +1185,14 @@ class BatSurvey(BatObservation):
                             bkg_var_array = file[1].data[idx]["BKG_VAR"][0]
                             snr_array = file[1].data[idx]["VECTSNR"][0]
 
-                            self.set_pointing_info(id, "rate", rate_array, source_id=s)
+                            self.set_pointing_info(point_id, "rate", rate_array, source_id=s)
                             self.set_pointing_info(
-                                id, "rate_err", rate_err_array, source_id=s
+                                point_id, "rate_err", rate_err_array, source_id=s
                             )
                             self.set_pointing_info(
-                                id, "bkg_var", bkg_var_array, source_id=s
+                                point_id, "bkg_var", bkg_var_array, source_id=s
                             )
-                            self.set_pointing_info(id, "snr", snr_array, source_id=s)
+                            self.set_pointing_info(point_id, "snr", snr_array, source_id=s)
 
                             # this does the calculation for the total energy range so set the if statement so the
                             # mosaic results dont attempt to calculate a wrong energy integrated count rate
@@ -1200,41 +1202,42 @@ class BatSurvey(BatObservation):
                                     rate_tot,
                                     rate_err_2_tot,
                                     snr_allband_num,
-                                ) = self.get_count_rate(energy_idx, id, s)
+                                ) = self.get_count_rate(energy_idx, point_id, s)
 
                                 rate_array = np.concatenate(
-                                    (self.pointing_info[id][s]["rate"], [rate_tot])
+                                    (self.pointing_info[point_id][s]["rate"], [rate_tot])
                                 )
                                 rate_err_array = np.concatenate(
                                     (
-                                        self.pointing_info[id][s]["rate_err"],
+                                        self.pointing_info[point_id][s]["rate_err"],
                                         [rate_err_2_tot],
                                     )
                                 )
                                 snr_array = np.concatenate(
                                     (
-                                        self.pointing_info[id][s]["snr"],
+                                        self.pointing_info[point_id][s]["snr"],
                                         [snr_allband_num],
                                     )
                                 )
                                 # bkg_var_array = np.concatenate((bkg_var_array, [np.sqrt(bkg_var_2_tot)]))
 
                                 self.set_pointing_info(
-                                    id, "rate", rate_array, source_id=s
+                                    point_id, "rate", rate_array, source_id=s
                                 )
                                 self.set_pointing_info(
-                                    id, "rate_err", rate_err_array, source_id=s
+                                    point_id, "rate_err", rate_err_array, source_id=s
                                 )
                                 self.set_pointing_info(
-                                    id, "bkg_var", bkg_var_array, source_id=s
+                                    point_id, "bkg_var", bkg_var_array, source_id=s
                                 )
                                 self.set_pointing_info(
-                                    id, "snr", snr_array, source_id=s
+                                    point_id, "snr", snr_array, source_id=s
                                 )
                         else:
                             # a given pointing may not have the source in it so just raise a warning
                             try:
-                                warn_str = (f"Observation ID: {self.obs_id} Pointing ID: {id} \nThere is no source {s} "
+                                warn_str = (f"Observation ID: {self.obs_id} Pointing ID: {point_id} \n"
+                                            f"There is no source {s} "
                                             f"found in the catalog file. Please double check the spelling.\nThis "
                                             f"source may also not be detected in this observation ID/pointing ID")
                                 warnings.warn(warn_str)

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -6,16 +6,12 @@ Tyler Parsotan April 5 2023
 """
 import os
 import shutil
-import sys
 from .batlib import datadir, dirtest, met2mjd, met2utc
 from .batobservation import BatObservation
-import glob
 from astropy.io import fits
 import numpy as np
-import subprocess
 import pickle
 import sys
-import re
 from pathlib import Path
 from astropy.time import Time
 from datetime import datetime, timedelta
@@ -28,14 +24,7 @@ try:
 except ModuleNotFoundError as err:
     # Error handling
     print(err)
-
-
-# try:
-# import xspec as xsp
-# except ModuleNotFoundError as err:
-# Error handling
-# print(err)
-
+    
 
 class BatSurvey(BatObservation):
     """

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -11,7 +11,6 @@ from .batobservation import BatObservation
 from astropy.io import fits
 import numpy as np
 import pickle
-import sys
 from pathlib import Path
 from astropy.time import Time
 from datetime import datetime, timedelta

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -24,7 +24,7 @@ try:
 except ModuleNotFoundError as err:
     # Error handling
     print(err)
-    
+
 
 class BatSurvey(BatObservation):
     """
@@ -432,7 +432,7 @@ class BatSurvey(BatObservation):
                 mjdtime = met2mjd(time_array)
                 utctime = met2utc(time_array, mjd_time=mjdtime)
 
-                lc_fits.close
+                lc_fits.close()
 
                 # open the status file to save the success code
                 status_file = pointing.parent.joinpath(f"point_{id}_status.txt")
@@ -787,7 +787,7 @@ class BatSurvey(BatObservation):
                 # bkg_var = tbdata.field('BKG_VAR')
                 theta_array = tbdata.field("THETA")
                 phi_array = tbdata.field("PHI")
-                cat_file.close
+                cat_file.close()
 
                 # if we want to calculate or recalculate pha for certain pointings we modify the arrays to just the values
                 # of interest
@@ -868,7 +868,7 @@ class BatSurvey(BatObservation):
                         ra_pnt = org_cat_data.field("RA_PNT")[0]
                         dec_pnt = org_cat_data.field("DEC_PNT")[0]
                         pa_pnt = org_cat_data.field("PA_PNT")[0]
-                        org_cat_file.close
+                        org_cat_file.close()
 
                         attfile = self.result_dir.joinpath(
                             f"{pointing_array[i]}"
@@ -1615,7 +1615,7 @@ class MosaicBatSurvey(BatSurvey):
          Calls batcelldetect to detect sources in the mosaic image that is encompassed by a given MosaicBatSurvey object
     """
 
-    def __init__(self, mosaic_dir, recalc=False, load_dir=None):
+    def __init__(self, mosaic_dir, recalc=False):
         """
         Initializer method for the MosaicBatSurvey object.
 
@@ -1623,7 +1623,6 @@ class MosaicBatSurvey(BatSurvey):
         :param recalc: Boolean default False, which indicates that the method should try to load data from a file in
             the mosaic_dir directory. True means that the load file will be ignored and attributes will be re-obtaiend
             for the object.
-        :param load_dir: Not used
         """
 
         # this isnt proper usage of super classes since the below lines are in the init of the BatSurvey class
@@ -1696,7 +1695,7 @@ class MosaicBatSurvey(BatSurvey):
                 tbin_start_met = file_header["S_TBIN"]
                 tbin_end_met = file_header["E_TBIN"]
 
-                file.close
+                file.close()
 
                 tbin_start_mjdtime = met2mjd(tbin_start_met)
                 tbin_start_utctime = met2utc(
@@ -1991,7 +1990,7 @@ class MosaicBatSurvey(BatSurvey):
                     count_rate_err_array = tbdata.field("BKG_VAR")
                     scale = 1
 
-                cat_file.close
+                cat_file.close()
 
                 # check = 0
                 # make pha file

--- a/batanalysis/bat_survey.py
+++ b/batanalysis/bat_survey.py
@@ -1889,25 +1889,25 @@ class MosaicBatSurvey(BatSurvey):
         if not copied_responsefile.exists():
             copied_responsefile.symlink_to(responsefile)
 
-        for id in id_list:
+        for ident in id_list:
             if verbose:
-                print("Creating PHA file for ", id)
+                print("Creating PHA file for ", ident)
 
             # get the proper name for the source incase the user didnt get the name correct
             x = sorted(merge_output_path.glob("*.cat"))
             catalog_sources = [i.stem for i in x]
-            test = self._compare_source_name(id, catalog_sources)
+            test = self._compare_source_name(ident, catalog_sources)
             if np.sum(test) > 0:
-                id = np.array(catalog_sources)[
-                    self._compare_source_name(id, catalog_sources)
+                ident = np.array(catalog_sources)[
+                    self._compare_source_name(ident, catalog_sources)
                 ][0]
             else:
-                id = None
+                ident = None
 
             # get info from the newly created cat file (from merge)
             try:
                 catalog = merge_output_path.joinpath(
-                    f"{id}.cat"
+                    f"{ident}.cat"
                 )
                 cat_file = fits.open(catalog)
                 tbdata = cat_file[1].data
@@ -1971,11 +1971,11 @@ class MosaicBatSurvey(BatSurvey):
 
                 if calc_upper_lim:
                     survey_pha_file = output_dir.joinpath(
-                        f"{id}_mosaic_bkgnsigma_{int(bkg_nsigma)}_upperlim.pha"
+                        f"{ident}_mosaic_bkgnsigma_{int(bkg_nsigma)}_upperlim.pha"
                     )
 
                 else:
-                    survey_pha_file = output_dir.joinpath(f"{id}_mosaic.pha")
+                    survey_pha_file = output_dir.joinpath(f"{ident}_mosaic.pha")
                 self.set_pha_filenames(survey_pha_file)
                 pha_thdulist.writeto(str(survey_pha_file))
 
@@ -2042,4 +2042,4 @@ class MosaicBatSurvey(BatSurvey):
 
                 pha_hdulist.flush()
             except FileNotFoundError:
-                print("The source %s was not found in the mosaiced image." % (id))
+                print("The source %s was not found in the mosaiced image." % (ident))

--- a/batanalysis/batlib.py
+++ b/batanalysis/batlib.py
@@ -28,6 +28,7 @@ except ModuleNotFoundError as err:
 
 _orig_pdir = os.getenv("PFILES")
 
+
 def dirtest(directory, clean_dir=True):
     """
     Tests if a directory exists and either creates the directory or removes it and then re-creates it
@@ -64,7 +65,8 @@ def datadir(new=None, mkdir=False, makepersistent=False, tdrss=False) -> Path:
     Args:
         new (Path|str, optional): Use this as the data directory
         mkdir (bool, optional): Create the directory (and its parents) if necessary
-        makepersistent (bool, optional): If set, stores the name in ~/.swift/swift_datadir_name and uses it as new default
+        makepersistent (bool, optional): If set, stores the name in ~/.swift/swift_datadir_name and uses it as new
+            default
         tdrss (bool, optional): subdirectory storing tdrss data types
     """
     global _datadir
@@ -238,7 +240,7 @@ def combine_survey_lc(survey_obsid_list, output_dir=None, clean_dir=True):
     if type(survey_obsid_list) is not list:
         survey_obsid_list = [survey_obsid_list]
 
-    # get the main directory where we shoudl create the total_lc directory
+    # get the main directory where we should create the total_lc directory
     if output_dir is None:
         output_dir = survey_obsid_list[0].result_dir.parent.joinpath(
             "total_lc"
@@ -246,10 +248,10 @@ def combine_survey_lc(survey_obsid_list, output_dir=None, clean_dir=True):
     else:
         output_dir = Path(output_dir).expanduser().resolve()
 
-    # if the directory doesnt exist, create it otherwise over write it
+    # if the directory doesn't exist, create it otherwise overwrite it
     dirtest(output_dir, clean_dir=clean_dir)
 
-    # make the local pfile dir if it doesnt exist and set this value
+    # make the local pfile dir if it doesn't exist and set this value
     _local_pfile_dir = output_dir.joinpath(".local_pfile")
     _local_pfile_dir.mkdir(parents=True, exist_ok=True)
     try:
@@ -284,7 +286,7 @@ def read_lc_data(filename, energy_band_index=None, T0=0):
     :return: arrays of the time, time bin size, rate, rate_error, and the SNR of the measurement in time
     """
 
-    ## get fits file data
+    # get fits file data
     time = []
     time_err = []
     rate = []
@@ -297,7 +299,7 @@ def read_lc_data(filename, energy_band_index=None, T0=0):
 
     time_array = lc_fits_data.field("TIME")
     timestop_array = lc_fits_data.field("TIME_STOP")
-    exposure_array = lc_fits_data.field("EXPOSURE")
+    #exposure_array = lc_fits_data.field("EXPOSURE") this isn't needed
     rate_array = lc_fits_data.field("RATE")
     rate_err_array = lc_fits_data.field("RATE_ERR")
     bkg_var_array = lc_fits_data.field("BKG_VAR")
@@ -306,8 +308,8 @@ def read_lc_data(filename, energy_band_index=None, T0=0):
     for i in range(len(lc_fits_data)):
         time_start = time_array[i] - T0  # this is in MET
         time_stop = timestop_array[i] - T0
-        time_mid = (time_start + time_stop) / 2.0 #we want to leave units as MET
-        time_err_num = (time_stop - time_start) / 2.0 #we want to leave units as MET
+        time_mid = (time_start + time_stop) / 2.0 # we want to leave units as MET
+        time_err_num = (time_stop - time_start) / 2.0 # we want to leave units as MET
 
         time.append(time_mid)
         time_err.append(time_err_num)
@@ -344,25 +346,23 @@ def read_lc_data(filename, energy_band_index=None, T0=0):
     return time, time_err, rate, rate_err, snr
 
 
-def calc_response(phafilename, srcname=None, indir=None, outdir=None):
+def calc_response(phafilename):
     """
-        This function generates the response matrix for a given pha file by calling batdrmgen (this is a HEASOFT function).
+        This function generates the response matrix for a given pha file by calling batdrmgen
+        (this is a HEASOFT function).
 
-        :param phafilename: String that denotes the location and name of the PHA file that the user would like to calculate
-            the response matrix for.
-        :param srcname: String denoting the source name (no spaces). The source name must match with the one that is in the phafilename.
-        :param indir: String denoting the full path/to/the/input-directory. By default it takes the current directory.
-        :param outdir: String denoting the full path/to/the/output-directory. By default it takes the current directory
-        :return: Heasoftpy "Result" object obtained from calling heasoftpy batdrmgen. The "Result" object is the entire output, which
-    helps to debug in case of an error.
+        :param phafilename: String that denotes the location and name of the PHA file that the user would like to
+            calculate the response matrix for.
+        :return: Heasoftpy "Result" object obtained from calling heasoftpy batdrmgen. The "Result" object is the entire
+            output, which helps to debug in case of an error.
     """
 
     if type(phafilename) is not list:
         phafilename = [phafilename]
 
-    # when passing in tht whole filename, the paths mess up the conection between the response file and the pha file since
-    # there seems to be some character limit to this header value. Therefore we need to cd to the directory that the PHA
-    # file lives in and create the .rsp file and then cd back to the original location.
+    # when passing in tht whole filename, the paths mess up the connection between the response file and the pha file
+    # since there seems to be some character limit to this header value. Therefore, we need to cd to the directory
+    # that the PHA file lives in and create the .rsp file and then cd back to the original location.
 
     # make sure that all elements are paths
     phafilename = [Path(i) for i in phafilename]
@@ -421,8 +421,6 @@ def fit_spectrum(
     plotting=True,
     generic_model=None,
     setPars=None,
-    indir=None,
-    outdir=None,
     use_cstat=True,
     fit_iterations=1000,
     verbose=True,
@@ -457,8 +455,6 @@ def fit_spectrum(
     :param plotting: Boolean statement, if the user wants to plot the spectrum.
     :param generic_model: String with XSPEC compatible model, which must include cflux.
     :param setPars: Boolean to set the parameter values of the model specified above.
-    :param indir: String denoting the full path/to/the/input-directory. By default it takes the current directory.
-    :param outdir: String denoting the full path/to/the/output-directory. By default it takes the current directory.
     :param use_cstat: Boolean to use cstat in case of low counts (Poisson statistics), otherwise use chi squared stats.
     :param fit_iterations: Number of fit iterations to be carried out by XSPEC.
      Since BAT data has just 8 energy channels, a default of 100 is enough.
@@ -520,9 +516,9 @@ def fit_spectrum(
         generic_model is not None
     ):  # User provides a string of model, and a Dictionary for the initial values
         if type(generic_model) is str:
-            if (
-                "cflux" in generic_model
-            ):  # The user must provide the cflux, or else we will not be able to predict of there is a statistical detection (in the next function).
+            if "cflux" in generic_model:
+                # The user must provide the cflux, or else we will not be able to predict of there is a statistical
+                # detection (in the next function).
                 try:
                     model = xsp.Model(
                         generic_model, setPars=setPars
@@ -557,11 +553,10 @@ def fit_spectrum(
         p5.frozen = True
 
         # model_components=model.componentNames  #This is a list of the model components
-    # Check if the model is XSPEC compatible : Done
-    # Listing down the model parameters in a dictionary: parm1: Value, param2: Value....
-    # If no initial values given , default XSPEC values to be used.
-    # We will manipulate these param values to "set a value" or "freeze/thaw" a value, set a range for these viable values.
-    # We can call the best fit param values, after fit.
+    # Check if the model is XSPEC compatible : Done Listing down the model parameters in a dictionary: parm1: Value,
+    # param2: Value.... If no initial values given , default XSPEC values to be used. We will manipulate these param
+    # values to "set a value" or "freeze/thaw" a value, set a range for these viable values. We can call the best fit
+    # param values, after fit.
 
     # Fitting the data with this model
 
@@ -576,7 +571,7 @@ def fit_spectrum(
     xsp.Fit.nIterations = fit_iterations
     xsp.Fit.renorm()
 
-    # try to do the fitting if it doesnt work fill in np.nan values for things
+    # try to do the fitting if it doesn't work fill in np.nan values for things
     try:
         xsp.Fit.perform()
         if verbose:
@@ -606,7 +601,8 @@ def fit_spectrum(
         if plotting:
             plt.show()
 
-        # Capturing the Flux and its error. saved to the model object, can be obtained by calling model(1).error, model(2).error
+        # Capturing the Flux and its error. saved to the model object, can be obtained by calling model(1).error,
+        # model(2).error
         model_params = dict()
         for i in range(1, model.nParameters + 1):
             xsp.Fit.error("2.706 %d" % (i))
@@ -685,12 +681,17 @@ def calculate_detection(
      For different sources one can specify separate detection threshold ('sigma') for different sources.
      Thus we have kept this function to operate only ONE source at a time.
 
-    :param surveyobservation: Object denoting the batsurvey observation object which contains all the necessary information related to this observation.
+    :param surveyobservation: Object denoting the batsurvey observation object which contains all the necessary
+        information related to this observation.
     :param source_id: String denoting the source name exactly as that in the phafilename.
-    :param pl_index: Float (default 2) denoting the power law photon index that will be used to obtain a flux upper limit
+    :param pl_index: Float (default 2) denoting the power law photon index that will be used to obtain a flux upper
+        limit
     :param nsigma: Integer, denoting the number fo sigma the user needs to justify a detection
-    :param bkg_nsigma: Integer, denoting the number of sigma the user needs to to calculate flux upper limit in case of a non detection.
-    :param verbose: Boolean to show every output during the fitting process. Set to True by default, that'll help the user to identify any issues with the fits.
+    :param bkg_nsigma: Integer, denoting the number of sigma the user needs to calculate flux upper limit in case
+        of a non detection.
+    :param plot_fit: Boolean to determine if the fit should be plotted or not
+    :param verbose: Boolean to show every output during the fitting process. Set to True by default, that'll help the
+        user to identify any issues with the fits.
     :return: In case of a non-detection a flux upper limit is returned.
     """
 
@@ -718,9 +719,11 @@ def calculate_detection(
 
     flux_upperlim = []
 
+    # By specifying the source_id, we now have the specific PHA filename list corresponding to the
+    # pointing_id_list for this given bat survey observation.
     phafilename_list = surveyobservation.get_pha_filenames(
         id_list=[source_id], pointing_id_list=pointing_ids
-    )  # By specifying the source_id, we now have the specific PHA filename list corresponding to the pointing_id_list for this given bat survey observation.
+    )
 
     for i in range(len(phafilename_list)):  # Loop over all phafilename_list,
         pha_dir = phafilename_list[i].parent
@@ -729,7 +732,8 @@ def calculate_detection(
         # The old statement: pointing_id=pha_file.split(".")[0].split("_")[-1] didnt work if source_id has period in it
         pointing_id = phafilename_list[i].stem.split("_")[-1]
 
-        # Within the pointing dictionar we have the "key" called "Xspec_model" which has the parameters, values and errors.
+        # Within the pointing dictionar we have the "key" called "Xspec_model" which has the parameters, values and
+        # errors.
         error_issues = False  # preset this here
         try:
             pointing_dict = surveyobservation.get_pointing_info(
@@ -758,7 +762,7 @@ def calculate_detection(
                 error_issues = True
 
         except ValueError:
-            # the fitting wasnt not successful and the dictionary was not created but want to enter the upper limit if
+            # the fitting was not successful and the dictionary was not created but want to enter the upper limit if
             # statement
             fluxerr_lolim = 0
             flux = 1
@@ -780,8 +784,8 @@ def calculate_detection(
                 single_pointing=pointing_id,
             )
 
-            # can also do surveyobservation.get_pha_filenames(id_list=source_id,pointing_id_list=pointing_id, getupperlim=True)
-            # to get the created upperlimit file. Will do this because it is more robust
+            # can also do surveyobservation.get_pha_filenames(id_list=source_id,pointing_id_list=pointing_id,
+            # getupperlim=True) to get the created upperlimit file. Will do this because it is more robust
             # bkgnsigma_upper_limit_pha_file= pha_file.split(".")[0]+'_bkgnsigma_%d'%(bkg_nsigma) + '_upperlim.pha'
             bkgnsigma_upper_limit_pha_file = surveyobservation.get_pha_filenames(
                 id_list=source_id, pointing_id_list=pointing_id, getupperlim=True
@@ -833,7 +837,8 @@ def calculate_detection(
 
                 print(s.flux)
 
-            # Capturing the simple model. saved to the model object, can be obtained by calling model(1).error, model(2).error
+            # Capturing the simple model. saved to the model object, can be obtained by calling model(1).error,
+            # model(2).error
             model_params = dict()
             for j in range(1, model.nParameters + 1):
                 # get the name of the parameter
@@ -885,12 +890,12 @@ def print_parameters(
         correspond to the keys in the pointing_info dictionaries of each BatSurvey object and the colmns will be put
         in this order.
     :param energy_range: a list or array of the minimum energy range that should be considered and the maximum energy
-        range that should be considered. By default this is 14-195 keV
+        range that should be considered. By default, this is 14-195 keV
     :param latex_table: Boolean to denote if the output should be formatted as a latex table
     :param savetable: Boolean to denote if the user wants to save the table to a file
     :param save_file: string that specified the location and name of the file that contains the saved table
     :param overwrite: Boolean that says to overwrite the output file if it already exists
-    :param add_obs_id: Moolean to denote if the observation and pointing IDs should be added to the value list automatically
+    :param add_obs_id: Boolean to denote if the observation and pointing IDs should be added to the value list automatically
     :return: None
     """
 
@@ -1264,7 +1269,8 @@ def met2utc(met_time, mjd_time=None):
 
     :param met_time: a number that is the Swift MET time that will be converted
     :param mjd_time: default to None, which means that the code will first calculate the MJD time and then convert it to
-        UTC time. If the user already has the MJD time, they can specify it here and the function will directly convert it.
+        UTC time. If the user already has the MJD time, they can specify it here and the function will directly
+        convert it.
     :return: a numpy datetime64 object of the MET time with the Swift clock correction applied
     """
     if mjd_time is None:
@@ -1298,7 +1304,7 @@ def set_pdir(pdir):
     :return:
     """
 
-    # if its not None, make sure that its a string that can be passed to heasoftpy. None will
+    # if it's not None, make sure that it's a string that can be passed to heasoftpy. None will
     if pdir is not None:
         pdir = str(pdir)
 
@@ -1321,19 +1327,20 @@ def concatenate_data(
     bat_observation, source_ids, keys, energy_range=[14, 195], chronological_order=True
 ):
     """
-    This convenience function collects the data that was requested by the user as passed into the keys variable. The data
-    is returned in the form of a dictionary with the same keys and numpy arrays of all the concatenated data. if the user asks
-    for parameters with errors associated with them these errors will be automatically included. For example if the user wants
-    rates information then the function will automatically include a dicitonary key to hold the rates error information as well
+    This convenience function collects the data that was requested by the user as passed into the keys variable. The
+    data is returned in the form of a dictionary with the same keys and numpy arrays of all the concatenated data. if
+    the user asks for parameters with errors associated with them these errors will be automatically included. For
+    example if the user wants rates information then the function will automatically include a dicitonary key to
+    hold the rates error information as well
 
-    :param bat_observation: a list of BatObservation objects including BatSurvey and MosaicBatSurvey objects that the user
-        eants to extract the relevant data from.
+    :param bat_observation: a list of BatObservation objects including BatSurvey and MosaicBatSurvey objects that the
+        user wants to extract the relevant data from.
     :param source_ids: The sources that the user would like to collect data for
     :param keys: a string or list of strings
     :param energy_range: a list or array of the minimum energy range that should be considered and the maximum energy
         range that should be considered
-    :param chronological_order: Boolean to denote if the outputs should be sorted chronologically or kept in the same order
-        as the BATSurvey objects that were passed in
+    :param chronological_order: Boolean to denote if the outputs should be sorted chronologically or kept in the same
+        order as the BATSurvey objects that were passed in
     :return: dict with the keys specified by the user and numpy lists as the concatenated values for each key
     """
 
@@ -1359,8 +1366,8 @@ def concatenate_data(
         for j in concat_data[i].keys():
             concat_data[i][j] = []
 
-    # deterine the energy range that may be of interest. This can be none for total E range or one of the basic 8 channel
-    # energies or a range that spans more than one energy range of the 8 channels.
+    # deterine the energy range that may be of interest. This can be none for total E range or one of the basic 8
+    # channel energies or a range that spans more than one energy range of the 8 channels.
     if np.isclose([14, 195], energy_range).sum() == 2:
         e_range_idx = [-1]  # this is just the last index of the arrays for counts, etc
     else:
@@ -1410,14 +1417,14 @@ def concatenate_data(
                             concat_data[source][user_key].append(save_val)
                             save_val = (
                                 np.inf
-                            )  # set to a crazy number so we dont get errors with np.isnan for a string
+                            )  # set to a crazy number so we don't get errors with np.isnan for a string
 
                         if "pointing" in user_key:
                             save_val = pointings
                             concat_data[source][user_key].append(save_val)
                             save_val = (
                                 np.inf
-                            )  # set to a crazy number so we dont get errors with np.isnan for a string
+                            )  # set to a crazy number so we don't get errors with np.isnan for a string
 
                         # search in all
                         continue_search = True
@@ -1441,7 +1448,8 @@ def concatenate_data(
                                 and ("index" not in user_key.lower())
                             ):
                                 try:
-                                    # if this is a rate/rate_err/snr need to calcualate these quantities based on the returned array
+                                    # if this is a rate/rate_err/snr need to calcualate these quantities based on the
+                                    # returned array
                                     if "rate" in user_key or "snr" in user_key:
                                         rate, rate_err, snr = obs.get_count_rate(
                                             e_range_idx, pointings, source
@@ -1457,10 +1465,11 @@ def concatenate_data(
                                         save_val = dpath.get(dictionary, user_key)
 
                                 except KeyError:
-                                    # if the key doest exist dont do anything but add np.nan
+                                    # if the key doest exist don't do anything but add np.nan
                                     save_val = np.nan
-                                    # this key for rate, rate_err, SNR doesnt exist probably because the source wasnt
-                                    # detected so dont eneter the outer if statement again 9which will keep saving np.nan
+                                    # this key for rate, rate_err, SNR doesn't exist probably because the source wasn't
+                                    # detected so don't enter the outer if statement again which will keep saving
+                                    # np.nan
                                     if "rate" in user_key or "snr" in user_key:
                                         continue_search = False
 
@@ -1475,7 +1484,7 @@ def concatenate_data(
                             in obs.get_pointing_info(pointings, source_id=source).keys()
                         ):
                             # can have obs.get_pointing_info(pointings, source_id=source)["model_params"]
-                            # but it can be None if the source isnt detected
+                            # but it can be None if the source isn't detected
                             # if obs.get_pointing_info(pointings, source_id=source)["model_params"] is not None:
                             # have to modify the name of the flux related quantity here
                             if "flux" in user_key.lower():
@@ -1492,7 +1501,7 @@ def concatenate_data(
                                     real_user_key,
                                 )
                             except KeyError:
-                                # if the key doest exist dont do anything but add np.nan
+                                # if the key doest exist don't do anything but add np.nan
                                 save_val = np.nan
                                 # if the value that we want is flux but we only have an upper limit then we have to get
                                 # the nsigma_lg10flux_upperlim value
@@ -1507,7 +1516,7 @@ def concatenate_data(
                                             real_user_key,
                                         )
                                     except KeyError:
-                                        # if the key doest exist dont do anything but add np.nan
+                                        # if the key doest exist don't do anything but add np.nan
                                         save_val = np.nan
 
                             # need to calculate the error on the value
@@ -1541,8 +1550,9 @@ def concatenate_data(
                                             error = np.abs(save_value - error)
 
                                     except TypeError:
-                                        # this is the last resort for catching any keys that arent found in the dict so we may
-                                        # have save_val be = np.nan and we will get TypeError trying to call it as a dict
+                                        # this is the last resort for catching any keys that aren't found in the dict
+                                        # so we may have save_val be = np.nan and we will get TypeError trying to
+                                        # call it as a dict
                                         save_value = np.nan
                                         error = np.ones(2) * np.nan
 
@@ -1582,7 +1592,7 @@ def make_fake_tdrss_message(
     obs_id, trig_time, trig_stop, ra_obj, dec_obj, obs_dir=None
 ):
     """
-    This function creates a fake TDRSS message file that specifies a few important peices of information which can be
+    This function creates a fake TDRSS message file that specifies a few important pieces of information which can be
     used in the BAT TTE data processing pipeline.
 
     :param obs_id:

--- a/batanalysis/batlib.py
+++ b/batanalysis/batlib.py
@@ -44,11 +44,9 @@ def dirtest(directory, clean_dir=True):
         if clean_dir:
             # remove the directory and recreate it
             shutil.rmtree(directory)
-            # os.mkdir(directory)
             directory.mkdir(parents=True)
     else:
         # create it
-        # os.mkdir(directory)
         directory.mkdir(parents=True)
 
 
@@ -168,10 +166,10 @@ def create_custom_catalog(
     prev_name = catalog_name.stem
     cat = catalog_dir.joinpath(
         prev_name + "_prev.cat"
-    )  # os.path.join(catalog_dir, prev_name+"_prev.cat")
+    )
     final_cat = catalog_dir.joinpath(
         catalog_name
-    )  # os.path.join(catalog_dir, catalog_name)
+    )
 
     # create the columns of file
     c1 = fits.Column(
@@ -216,7 +214,6 @@ def create_custom_catalog(
 
     # need to get the file name off to get the dir this file is located in
     dir = Path(__file__[::-1].partition("/")[-1][::-1])
-    # hsp.ftmerge(infile="%s %s" % (os.path.join(dir, 'data/survey6b_2.cat'), str(cat)), outfile=str(final_cat))
     hsp.ftmerge(
         infile="%s %s"
         % (str(dir.joinpath("data").joinpath("survey6b_2.cat")), str(cat)),
@@ -224,22 +221,8 @@ def create_custom_catalog(
     )
 
     os.system("rm %s" % (str(cat)))
-    # cat.unlink()
 
     return final_cat
-
-
-def _source_name_converter(name):
-    """
-    This function converts a source name to one that may correspond to the file name found in a merged_pointings_lc directory.
-    This function is needed due to the name change with the batsurvey-catmux script.
-
-    :param name: a string or list of strings of dfferent source names
-    :return: string or list of strings
-    """
-
-    return " "
-
 
 def combine_survey_lc(survey_obsid_list, output_dir=None, clean_dir=True):
     """
@@ -263,8 +246,6 @@ def combine_survey_lc(survey_obsid_list, output_dir=None, clean_dir=True):
     else:
         output_dir = Path(output_dir).expanduser().resolve()
 
-    # if not os.path.isdir(output_dir):
-    #    raise ValueError('The directory %s needs to exist for this function to save its results.' % (output_dir))
     # if the directory doesnt exist, create it otherwise over write it
     dirtest(output_dir, clean_dir=clean_dir)
 
@@ -283,14 +264,10 @@ def combine_survey_lc(survey_obsid_list, output_dir=None, clean_dir=True):
                 keycolumn="NAME",
                 infile=str(i),
                 outfile=str(output_dir.joinpath("%s.cat")),
-            )  # os.path.join(output_dir, "%s.cat"))
+            )
 
             # there is a bug in the heasoftpy code so try to explicitly call it for now
             ret.append(hsp.batsurvey_catmux(**dictionary))
-            # input_string = "batsurvey-catmux "
-            # for i in dictionary:
-            #    input_string = input_string + "%s=%s " % (str(i), dictionary[i])
-            # os.system(input_string)
 
     return output_dir
 
@@ -329,10 +306,8 @@ def read_lc_data(filename, energy_band_index=None, T0=0):
     for i in range(len(lc_fits_data)):
         time_start = time_array[i] - T0  # this is in MET
         time_stop = timestop_array[i] - T0
-        time_mid = (time_start + time_stop) / 2.0
-        # time_mid = time_mid / (24 * 60 * 60) #comment because we want to leave units as MET
-        time_err_num = (time_stop - time_start) / 2.0
-        # time_err_num = time_err_num / (24 * 60 * 60) #comment because we want to leave units as MET
+        time_mid = (time_start + time_stop) / 2.0 #we want to leave units as MET
+        time_err_num = (time_stop - time_start) / 2.0 #we want to leave units as MET
 
         time.append(time_mid)
         time_err.append(time_err_num)
@@ -364,7 +339,7 @@ def read_lc_data(filename, energy_band_index=None, T0=0):
                 snr_allband_num = rate_tot / np.sqrt(bkg_var_2_tot)
                 snr.append(snr_allband_num)
 
-    lc_fits.close
+    lc_fits.close()
 
     return time, time_err, rate, rate_err, snr
 
@@ -396,7 +371,7 @@ def calc_response(phafilename, srcname=None, indir=None, outdir=None):
     # we are already located in the PHA directory and are mabe calculating the upperlimit bkg spectrum
     _local_pfile_dir = (
         phafilename[0].resolve().parents[1].joinpath(".local_pfile")
-    )  # Path(f"/tmp/met2mjd_{os.times().elapsed}")
+    )
     _local_pfile_dir.mkdir(parents=True, exist_ok=True)
     try:
         hsp.local_pfiles(pfiles_dir=str(_local_pfile_dir))
@@ -405,7 +380,6 @@ def calc_response(phafilename, srcname=None, indir=None, outdir=None):
 
     # Check if the phafilename is a string and if it has an extension .pha. If NOT then exit
     for filename in phafilename:
-        # if type(filename) is not str or '.pha' not in os.path.splitext(filename)[1]:
         if ".pha" not in filename.name:
             raise ValueError(
                 "The file name %s needs to be a string and must have an extension of .pha ."
@@ -416,19 +390,18 @@ def calc_response(phafilename, srcname=None, indir=None, outdir=None):
         current_dir = Path.cwd()
 
         # get the directory that we have to cd to and the name of the file
-        # pha_dir, pha_file=os.path.split(filename)
         pha_dir = filename.parent
         pha_file = filename.name
 
         # cd to that dir
-        # if str(pha_dir) != '':
         if str(pha_dir) != str(current_dir):
             os.chdir(pha_dir)
 
         # Split the filename by extension, so as to remove the .pha and replace it with .rsp
+        # this is necessary since sources can have '.' in name
         out = (
             filename.stem + ".rsp"
-        )  # pha_file.split(".")[0] + '.rsp', remove this since sources can have '.' in name
+        )
 
         # create drm
         output = hsp.batdrmgen(
@@ -436,11 +409,8 @@ def calc_response(phafilename, srcname=None, indir=None, outdir=None):
         )
 
         # cd back
-        # if pha_dir != '':
         if str(pha_dir) != str(current_dir):
             os.chdir(current_dir)
-
-    # shutil.rmtree(_local_pfile_dir)
 
     return output
 
@@ -512,10 +482,8 @@ def fit_spectrum(
     # get the cwd.
     phafilename = Path(phafilename)
     current_dir = Path.cwd()
-    # plt.ion()
 
     # Check if the phafilename is a string and if it has an extension .pha. If NOT then exit
-    # if type(phafilename) is not str or '.pha' not in  os.path.splitext(phafilename)[1]:
     if ".pha" not in phafilename.name:
         raise ValueError(
             "The file name %s needs to be a string and must have an extension of .pha ."
@@ -523,7 +491,6 @@ def fit_spectrum(
         )
 
     # get the directory that we have to cd to and the name of the file
-    # pha_dir, pha_file=os.path.split(phafilename)
     pha_dir = phafilename.parent
     pha_file = phafilename.name
 
@@ -531,7 +498,7 @@ def fit_spectrum(
     pointing_id = phafilename.stem.split("_")[-1]
 
     if len(pha_file.split("_survey")) > 1:
-        # weve got a pha for a normal survey catalog
+        # we've got a pha for a normal survey catalog
         source_id = pha_file.split("_survey")[
             0
         ]  # This is the source name compatible with the catalog
@@ -540,18 +507,15 @@ def fit_spectrum(
         source_id = pha_file.split("_mosaic")[0]
 
     # cd to that dir
-    # if pha_dir != '':
     if str(pha_dir) != str(current_dir):
         os.chdir(pha_dir)
 
     xsp.AllData -= "*"
     s = xsp.Spectrum(
         pha_file
-    )  # from xspec import * has been done at the top. This is a spectrum object
-    # s.ignore("**-15,150-**")	#Ignoring energy ranges below 15 and above 150 keV.
+    )
 
     # Define model
-
     if (
         generic_model is not None
     ):  # User provides a string of model, and a Dictionary for the initial values
@@ -638,7 +602,7 @@ def fit_spectrum(
         ax.set_yscale("log")
         f.savefig(
             phafilename.parent.joinpath(phafilename.stem + ".pdf")
-        )  # phafilename.split('.')[0]+'.pdf')
+        )
         if plotting:
             plt.show()
 
@@ -677,26 +641,19 @@ def fit_spectrum(
         )
 
     # Incorporating the model names, parameters, errors into the BatSurvey object.
-    xsp.Xset.save(phafilename.stem + ".xcm")  # pha_file.split(".")[0]
+    xsp.Xset.save(phafilename.stem + ".xcm")
     xspec_savefile = phafilename.parent.joinpath(
         phafilename.stem + ".xcm"
-    )  # os.path.join(pha_dir, pha_file.split(".")[0] + ".xcm")
+    )
     surveyobservation.set_pointing_info(
         pointing_id, "xspec_model", xspec_savefile, source_id=source_id
     )
 
-    # xsp.Fit.error("2.706 3")
-    # fluxerr_lolim = p3.error[0]
-    # fluxerr_hilim =p3.error[1]
-    # pyxspec_error_string=p3.error[2]   #The string which says if everything is correct. Should be checked if there is non-normal value.
-    # flux = p3.values[0]
-
     # cd back
-    # if pha_dir != '':
     if str(pha_dir) != str(current_dir):
         os.chdir(current_dir)
 
-    # return flux, (fluxerr_lolim, fluxerr_hilim), pyxspec_error_string
+    return None
 
 
 def calculate_detection(
@@ -746,22 +703,16 @@ def calculate_detection(
             "The pyXspec package needs to installed to determine if a source has been detected with this function."
         )
 
-    # flux=np.power(10,flux)
-    # fluxerr=np.power(10,flux)- np.power(10,(flux-fluxerr))
-
     current_dir = Path.cwd()
 
     # get the directory that we have to cd to and the name of the file
-    # pha_dir,_=os.path.split(surveyobservation.get_pha_filenames(id_list=[source_id])[0])
     pha_dir = surveyobservation.get_pha_filenames(id_list=[source_id])[0].parent
-    # original_pha_file_list= surveyobservation.pha_file_names_list.copy()
 
     pointing_ids = (
         surveyobservation.get_pointing_ids()
     )  # This is a list of pointing_ids in this bat survey observation
 
     # cd to that dir
-    # if pha_dir != '':
     if str(pha_dir) != str(current_dir):
         os.chdir(pha_dir)
 
@@ -772,7 +723,6 @@ def calculate_detection(
     )  # By specifying the source_id, we now have the specific PHA filename list corresponding to the pointing_id_list for this given bat survey observation.
 
     for i in range(len(phafilename_list)):  # Loop over all phafilename_list,
-        # pha_dir, pha_file=os.path.split(phafilename_list[i])
         pha_dir = phafilename_list[i].parent
         pha_file = phafilename_list[i].name
 
@@ -785,8 +735,6 @@ def calculate_detection(
             pointing_dict = surveyobservation.get_pointing_info(
                 pointing_id, source_id=source_id
             )
-            # xsp.Xset.restore(os.path.split(pointing_dict['xspec_model'])[1])
-            # model=xsp.AllModels(1)
             model = pointing_dict["model_params"]["lg10Flux"]
             flux = model["val"]  # ".cflux.lg10Flux.values[0]              #Value
             fluxerr_lolim = model["lolim"]  # .cflux.lg10Flux.error[0]      #Error
@@ -886,18 +834,14 @@ def calculate_detection(
                 print(s.flux)
 
             # Capturing the simple model. saved to the model object, can be obtained by calling model(1).error, model(2).error
-            # if the original fit had failed b/c of negative counts
-            # try:
-            #    pointing_dict = surveyobservation.get_pointing_info(pointing_id, source_id=source_id)
-            # except ValueError:
             model_params = dict()
-            for i in range(1, model.nParameters + 1):
+            for j in range(1, model.nParameters + 1):
                 # get the name of the parameter
-                par_name = model(i).name
+                par_name = model(j).name
                 model_params[par_name] = dict(
-                    val=model(i).values[0],
-                    lolim=model(i).error[0],
-                    hilim=model(i).error[1],
+                    val=model(j).values[0],
+                    lolim=model(j).error[0],
+                    hilim=model(j).error[1],
                     errflag="TTTTTTTTT",
                 )
             surveyobservation.set_pointing_info(
@@ -910,22 +854,11 @@ def calculate_detection(
                 np.log10(s.flux[0]),
                 source_id=source_id,
             )
-
-            # pointing_id=pha_file.split(".")[0].split("_")[-1]
-            # surveyobservation.pointing_info[pointing_id]["flux"]=0
-            # surveyobservation.pointing_info[pointing_id]["flux_lolim"]=0
-            # surveyobservation.pointing_info[pointing_id]["flux_hilim"]=s.flux[0]
-
         else:  # Detection
             if verbose:
                 print("A detection has been measured at the %d sigma level" % (nsigma))
-            # pointing_id=pha_file.split(".")[0].split("_")[-1]
-            # surveyobservation.pointing_info[pointing_id]["flux"]=flux[i]
-            # surveyobservation.pointing_info[pointing_id]["flux_lolim"]=fluxerr_lolim[i]
-            # surveyobservation.pointing_info[pointing_id]["flux_hilim"]=fluxerr_hilim[i]
 
     # cd back
-    # if pha_dir != '':
     if str(pha_dir) != str(current_dir):
         os.chdir(current_dir)
 
@@ -985,13 +918,6 @@ def print_parameters(
     if savetable and save_file is not None:
         # open the file to write the output to
         f = open(str(save_file), "w")
-
-    # dont allow xspec to prompt
-    # xsp.Xset.allowPrompting = False
-
-    # sort the obs ids by time of 1st pointing id
-    # all_met=[i.pointing_info[i.pointing_ids[0]]["met_time"] for i in obs_list]
-    # sorted_obs_idx=np.argsort(all_met)
 
     outstr = " "  # Obs ID  \t Pointing ID\t"
     for i in values:
@@ -1315,13 +1241,6 @@ def met2mjd(met_time):
     try:
         val = sbu.met2mjd(met_time, correct=True)
     except (ModuleNotFoundError, RuntimeError):
-        # _local_pfile_dir=Path(f"/tmp/met2mjd_{os.times().elapsed}")
-        # _local_pfile_dir.mkdir(parents=True, exist_ok=True)
-        # try:
-        #    hsp.local_pfiles(pfiles_dir=str(_local_pfile_dir))
-        # except AttributeError:
-        #    hsp.utils.local_pfiles(par_dir=str(_local_pfile_dir))
-
         # calculate times in UTC and MJD units as well
         inputs = dict(
             intime=str(met_time),
@@ -1331,9 +1250,7 @@ def met2mjd(met_time):
             outformat="m",
         )  # output in MJD
         o = hsp.swifttime(**inputs)
-        # stop
         val = float(o.params["outtime"])
-        # shutil.rmtree(_local_pfile_dir)
 
     atime = Time(val, format="mjd", scale="utc")
     return atime.value

--- a/batanalysis/batlib.py
+++ b/batanalysis/batlib.py
@@ -1,30 +1,23 @@
 """
 This file holds various functions that users can call to interface with bat observation objects
 """
-import subprocess
-import os
 import astropy as ap
 from astropy.io import fits
 from astropy.time import Time
 import numpy as np
 import shutil
 import matplotlib.pyplot as plt
-import glob
 import os
-import sys
 import warnings
 from pathlib import Path
 import requests
 from astroquery.heasarc import Heasarc
-from copy import copy
 import swifttools.swift_too as swtoo
 import datetime
 import dpath
 from concurrent.futures import ThreadPoolExecutor
 import functools
-
-
-# from xspec import *
+import swiftbat.swutil as sbu
 
 # for python>3.6
 try:
@@ -33,18 +26,7 @@ except ModuleNotFoundError as err:
     # Error handling
     print(err)
 
-# try:
-#    import xspec as xsp
-# except ModuleNotFoundError as err:
-# Error handling
-#    print(err)
-
-import swiftbat.swutil as sbu
-import swiftbat
-
-
 _orig_pdir = os.getenv("PFILES")
-
 
 def dirtest(directory, clean_dir=True):
     """

--- a/batanalysis/batobservation.py
+++ b/batanalysis/batobservation.py
@@ -3,40 +3,15 @@ This file contains the batobservation class which contains information pertainin
 
 Tyler Parsotan Jan 24 2022
 """
-import shutil
-import sys
-from .batlib import datadir, dirtest, met2mjd, met2utc
-import glob
-from astropy.io import fits
-import numpy as np
-import subprocess
-import pickle
-import sys
-import re
+
+from .batlib import datadir
 from pathlib import Path
-from astropy.time import Time
-from datetime import datetime, timedelta
-import re
-import warnings
-
-# for python>3.6
-try:
-    import heasoftpy as hsp
-except ModuleNotFoundError as err:
-    # Error handling
-    print(err)
-
-# try:
-# import xspec as xsp
-# except ModuleNotFoundError as err:
-# Error handling
-# print(err)
 
 
 class BatObservation(object):
     """
-    A general Bat Observation object that holds information about the observation ID and the directory of the observation
-    ID. This class ensures that the observation ID directory exists and throws an error if it does not.
+    A general Bat Observation object that holds information about the observation ID and the directory of the
+    observation ID. This class ensures that the observation ID directory exists and throws an error if it does not.
     """
 
     def __init__(self, obs_id, obs_dir=None):

--- a/batanalysis/batobservation.py
+++ b/batanalysis/batobservation.py
@@ -3,7 +3,6 @@ This file contains the batobservation class which contains information pertainin
 
 Tyler Parsotan Jan 24 2022
 """
-import os
 import shutil
 import sys
 from .batlib import datadir, dirtest, met2mjd, met2utc
@@ -56,7 +55,7 @@ class BatObservation(object):
             if obs_dir.joinpath(self.obs_id).is_dir():
                 self.obs_dir = obs_dir.joinpath(
                     self.obs_id
-                )  # os.path.join(obs_dir , self.obs_id)
+                )
             else:
                 raise FileNotFoundError(
                     "The directory %s does not contain the observation data corresponding to ID: %s"
@@ -66,10 +65,9 @@ class BatObservation(object):
             obs_dir = datadir()  # Path.cwd()
 
             if obs_dir.joinpath(self.obs_id).is_dir():
-                # os.path.isdir(os.path.join(obs_dir , self.obs_id)):
                 self.obs_dir = obs_dir.joinpath(
                     self.obs_id
-                )  # self.obs_dir = os.path.join(obs_dir , self.obs_id)
+                )
             else:
                 raise FileNotFoundError(
                     "The directory %s does not contain the observation data correponding to ID: %s"

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -292,7 +292,7 @@ def merge_outventory(survey_list, savedir=None):
         hdu.data = hdu.data[idx]
         hdul.flush()
 
-    return Path(outventory_file)
+    return Path(output_file)
 
 
 def select_outventory(outventory_file, start_met, end_met):

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -339,6 +339,8 @@ def group_outventory(
 
     #if the bins_datetime variable is set to none (the default) then we defualt to using the start/end_datetimes so need
     # to do input checks here
+    #also set this time_bins_is_list switch to false by default
+    time_bins_is_list = False
     if bins_datetime is None:
         if type(binning_timedelta) is not np.timedelta64:
             raise ValueError(
@@ -357,7 +359,7 @@ def group_outventory(
                     "The end_datetime variable needs to be an astropy Time object."
                 )
 
-        time_bins_is_list=False
+
     else:
         if type(bins_datetime) is not Time and type(bins_datetime) is not list:
                 raise ValueError(
@@ -371,6 +373,7 @@ def group_outventory(
                         "All the list elements of the bins_datetime variable needs to be an astropy Time object."
                     )
             time_bins_is_list=True
+
 
     # initalize the reference time for the Swift MET time (starts from 2001), used to calculate MET
     reference_time = Time("2001-01-01")

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -325,6 +325,7 @@ def group_outventory(
     start_datetime=None,
     end_datetime=None,
     recalc=False,
+    mjd_savedir=False
 ):
     """
     This function groups the observations listed in an outventory file together based on time bins that each observation
@@ -336,6 +337,9 @@ def group_outventory(
     :param start_datetime: An astropy Time object that denotes the start date to start binning the observations
     :param end_datetime: An astropy Time object that denotes the end date to stop binning the observations
     :param recalc: Boolean to denote if the directoruy at is created or not. Also denotes if the
+    :param mjd_savedir: Boolean to denote if the directory if the created directory has the datetime64 with the start date
+        of the beginning of the timebin of interest or if the directory name is formatted with mjd time (which is useful
+        for mosaicing with timebins shorter than a day)
     :return: numpy datetime array of the time bin edges that are created based on the user specification. This can be passed directly
         to the create_mosaic function.
     """

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -215,17 +215,18 @@ def merge_outventory(survey_list, savedir=None):
     if type(survey_list) is not list:
         raise ValueError("The input needs to be a list of BatSurvey objects.")
 
-    # need to find all the statfiles.lis and merge them and sort by time
-    #input_files = ""
-    #for obs in survey_list:
-    #    input_files += f'{obs.result_dir.joinpath("stats_point.fits")},'
-    #input_files = input_files[:-1]  # get rid of last comma
-
     if savedir is None:
         savedir = survey_list[0].result_dir.parent.joinpath("mosaiced_surveyresults")
     else:
         savedir = Path(savedir)
     dirtest(savedir, clean_dir=False)
+
+    # Below IS HEASOFT STUFF
+    # need to find all the statfiles.lis and merge them and sort by time
+    #input_files = ""
+    #for obs in survey_list:
+    #    input_files += f'{obs.result_dir.joinpath("stats_point.fits")},'
+    #input_files = input_files[:-1]  # get rid of last comma
 
     # create the pfile directory
     #local_pfile_dir = savedir.joinpath(".local_pfile")
@@ -267,11 +268,11 @@ def merge_outventory(survey_list, savedir=None):
     # get rid of the unsorted file
     #output_file.unlink()
     #input_filename.unlink()
-
+    # Above IS HEASOFT STUFF
 
     output_file = savedir.joinpath(
         "outventory_all.fits"
-    )  # os.path.join(savedir, "outventory_all_unsrt.fits")
+    )  
 
     shutil.copy(survey_list[0].result_dir.joinpath("stats_point.fits"),output_file)
     for i in survey_list[1:]:

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -382,14 +382,6 @@ def group_outventory(
     # make sure its a path object
     outventory_file = Path(outventory_file)
 
-    # create the pfile directory
-    local_pfile_dir = outventory_file.parent.joinpath(".local_pfile")
-    local_pfile_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        hsp.local_pfiles(pfiles_dir=str(local_pfile_dir))
-    except AttributeError:
-        hsp.utils.local_pfiles(par_dir=str(local_pfile_dir))
-
     #if we dont have the actual time bins passed in we need to calcualte them
     if  custom_timebins is None:
         # by default use the earliest date of outventory file
@@ -413,7 +405,7 @@ def group_outventory(
         if end_datetime is None:
             with fits.open(outventory_file) as f:
                 end_datetime = Time(met2utc(f[1].data["TSTART"].max()))
-            
+
 
         if binning_timedelta == np.timedelta64(1, "M"):
             # if the user wants months, need to specify each year, month and the number of days

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -925,8 +925,6 @@ def finalize_mosaic(intermediate_mosaic_directory):
         output_name = intermediate_mosaic_directory.joinpath(
             f"swiftbat_flatexp_c{i}.img"
         )
-        # input=dict(infile=str(file_name), outfile=str(output_name))
-        # hsp.ftcopy(**input)
         shutil.copy(file_name, output_name)
 
         with fits.open(output_name, mode="update") as file:
@@ -944,8 +942,6 @@ def finalize_mosaic(intermediate_mosaic_directory):
         output_name = intermediate_mosaic_directory.joinpath(
             f"swiftbat_exposure_c{i}.img"
         )
-        # input = dict(infile=str(file_name), outfile=str(output_name))
-        # hsp.ftcopy(**input)
         shutil.copy(file_name, output_name)
 
         with fits.open(output_name, mode="update") as file:
@@ -964,8 +960,6 @@ def finalize_mosaic(intermediate_mosaic_directory):
         flux_output_name = intermediate_mosaic_directory.joinpath(
             f"swiftbat_flux_c{i}.img"
         )
-        # input = dict(infile=str(flux_file_name), outfile=str(flux_output_name))
-        # hsp.ftcopy(**input)
         shutil.copy(flux_file_name, flux_output_name)
 
         # for the SNR, need to do simg/sqrt(vimg) and save this for each sky image and energy band
@@ -976,8 +970,6 @@ def finalize_mosaic(intermediate_mosaic_directory):
         snr_output_name = intermediate_mosaic_directory.joinpath(
             f"swiftbat_snr_c{i}.img"
         )
-        # input=dict(infile=str(snr_file_name), outfile=str(snr_output_name))
-        # hsp.ftcopy(**input)
         shutil.copy(snr_file_name, snr_output_name)
 
         # after calcualting the flux and the SNR, for the variance, need to convert from units of (1/cts/s)^2) to cts/s
@@ -988,8 +980,6 @@ def finalize_mosaic(intermediate_mosaic_directory):
         var_output_name = intermediate_mosaic_directory.joinpath(
             f"swiftbat_var_c{i}.img"
         )
-        # input=dict(infile=str(var_file_name), outfile=str(var_output_name))
-        # hsp.ftcopy(**input)
         shutil.copy(var_file_name, var_output_name)
 
         # open all the files in update mode
@@ -1210,12 +1200,6 @@ def _mosaic_loop(
         img_dir = outventory_file.parent.joinpath(
             f"mosaic_{start.mjd}"
         )
-
-
-    # make the local pfile dir if it doesnt exist and set this value
-    # local_pfile_dir=load_dir.joinpath(".local_pfile")
-    # local_pfile_dir.mkdir(parents=True, exist_ok=True)
-    # hsp.local_pfiles(pfiles_dir=str(local_pfile_dir))
 
     # see if there is a .batsurvey file, if it doesnt exist or if we want to recalc things then go through the full loop
     if not img_dir.joinpath("batsurvey.pickle").exists() or recalc:
@@ -1751,8 +1735,6 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
         # output_name=os.path.join(total_dir, f'expmap_{string}.img')
         file_name = intermediate_mosaic_dir_list[0].joinpath(f"expmap_{string}.img")
         output_name = total_dir.joinpath(f"expmap_{string}.img")
-        # input=dict(infile=str(file_name), outfile=str(output_name))
-        # hsp.ftcopy(**input)
         shutil.copy(file_name, output_name)
 
         with fits.open(str(output_name), mode="update") as file:
@@ -1777,8 +1759,6 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
         # input=dict(infile=file_name, outfile=output_name)
         file_name = intermediate_mosaic_dir_list[0].joinpath(f"pcode_{string}.img")
         output_name = total_dir.joinpath(f"pcode_{string}.img")
-        # input=dict(infile=str(file_name), outfile=str(output_name))
-        # hsp.ftcopy(**input)
         shutil.copy(file_name, output_name)
 
         with fits.open(str(output_name), mode="update") as file:
@@ -1803,8 +1783,6 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
         # input=dict(infile=file_name, outfile=var_output_name)
         file_name = intermediate_mosaic_dir_list[0].joinpath(f"var_{string}.img")
         var_output_name = total_dir.joinpath(f"var_{string}.img")
-        # input=dict(infile=str(file_name), outfile=str(var_output_name))
-        # hsp.ftcopy(**input)
         shutil.copy(file_name, var_output_name)
 
         # file_name=os.path.join(intermediate_mosaic_dir_list[0], f'flux_{string}.img')
@@ -1812,8 +1790,6 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
         # input=dict(infile=file_name, outfile=flux_output_name)
         file_name = intermediate_mosaic_dir_list[0].joinpath(f"flux_{string}.img")
         flux_output_name = total_dir.joinpath(f"flux_{string}.img")
-        # input=dict(infile=str(file_name), outfile=str(flux_output_name))
-        # hsp.ftcopy(**input)
         shutil.copy(file_name, flux_output_name)
 
         # open all the files in update mode

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -411,20 +411,9 @@ def group_outventory(
 
         # by default use the last entry of the outventory_file rounded to the nearest timedelta that the user is interested in
         if end_datetime is None:
-            val = hsp.ftlist(
-                infile=str(outventory_file),
-                rows="-",
-                option="T",
-                columns="tstart",
-                rownum="NO",
-            )
-            met_time = np.float64(val.output[-2])  # get the last row with the MET time
-
-            # call swifttime
-            # inputs = dict(intime=str(met_time), insystem="MET", informat="s", outsystem="UTC", outformat = "m")  # output in MJD
-            # o = hsp.swifttime(**inputs)
-            # end_datetime = Time(o.params["outtime"], format="mjd", scale='utc')
-            end_datetime = Time(met2utc(met_time))
+            with fits.open(outventory_file) as f:
+                end_datetime = Time(met2utc(f[1].data["TSTART"].max()))
+            
 
         if binning_timedelta == np.timedelta64(1, "M"):
             # if the user wants months, need to specify each year, month and the number of days

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -1897,7 +1897,7 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
 
 # Need to make sure that the sky facets have been created when this is imported
 # if this is the first time its imported need to create the default ones
-# if its not the first time this module is imported (ie that batanalysis is imported) then dont redo this calculation
+# if it's not the first time this module is imported (ie that batanalysis is imported) then dont redo this calculation
 
 package_data_dir = Path(__file__).parent.joinpath("data")
 files = sorted(package_data_dir.glob("*_ZEA.img"))

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -300,7 +300,7 @@ def select_outventory(outventory_file, start_met, end_met):
 
         #save the headers of the original outventory file and then copy them to the new output file
         hdu = f[1]
-        hdu.data = hdu.data[idx]
+        hdu.data = hdu.data[idx[0]]
         hdu.writeto(output_file)
 
 

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -311,7 +311,7 @@ def group_outventory(
     end_datetime=None,
     recalc=False,
     mjd_savedir=False,
-    bins_datetime=None,
+    custom_timebins=None,
     save_group_outventory=True
 ):
     """
@@ -337,11 +337,11 @@ def group_outventory(
 
     # error checking
 
-    #if the bins_datetime variable is set to none (the default) then we defualt to using the start/end_datetimes so need
+    #if the  custom_timebins variable is set to none (the default) then we defualt to using the start/end_datetimes so need
     # to do input checks here
     #also set this time_bins_is_list switch to false by default
     time_bins_is_list = False
-    if bins_datetime is None:
+    if  custom_timebins is None:
         if type(binning_timedelta) is not np.timedelta64:
             raise ValueError(
                 "The binning_timedelta variable needs to be a numpy timedelta64 object."
@@ -361,16 +361,17 @@ def group_outventory(
 
 
     else:
-        if type(bins_datetime) is not Time and type(bins_datetime) is not list:
+        if type( custom_timebins) is not Time and type( custom_timebins) is not list:
                 raise ValueError(
-                    "The bins_datetime variable needs to be an astropy Time object or a list of astropy Time objects."
+                    "The  custom_timebins variable needs to be an astropy Time object or a list of astropy Time objects."
                 )
         #make sure that all elements of list are astropy time objects and set a switch for later processing
-        if type(bins_datetime) is list:
-            for i in list:
+        if type( custom_timebins) is list:
+            for i in  custom_timebins:
                 if type(i) is not Time:
                     raise ValueError(
-                        "All the list elements of the bins_datetime variable needs to be an astropy Time object."
+                        "All the list elements of the  custom_timebins variable needs to be an astropy Time object of \
+                        dimension 2 x T, where T is the number of timebins of interest."
                     )
             time_bins_is_list=True
 
@@ -390,7 +391,7 @@ def group_outventory(
         hsp.utils.local_pfiles(par_dir=str(local_pfile_dir))
 
     #if we dont have the actual time bins passed in we need to calcualte them
-    if bins_datetime is None:
+    if  custom_timebins is None:
         # by default use the earliest date of outventory file
         if start_datetime is None:
             # use the swift launch date
@@ -475,8 +476,8 @@ def group_outventory(
         # convert to astropy time objects
         time_bins = Time(time_bins)
     else:
-        #need to convert the bins_datetime to the time_bins format which is trivial since they are already set to be that
-        time_bins = bins_datetime
+        #need to convert the  custom_timebins to the time_bins format which is trivial since they are already set to be that
+        time_bins =  custom_timebins
 
     #need to see if time_bins is a 1D Time array or a list of size N where there are N arrays of dimension 2xT where
     # there are T time bins of interest that will be combined into a grouped outventory file. The index 0 of the T

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -306,7 +306,7 @@ def select_outventory(outventory_file, start_met, end_met):
 
 def group_outventory(
     outventory_file,
-    binning_timedelta,
+    binning_timedelta=None,
     start_datetime=None,
     end_datetime=None,
     recalc=False,

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -1,12 +1,10 @@
 """
 This file is meant to hold the functions that allow users to create mosaic-ed images for survey data
 """
-import calendar
-from .batlib import dirtest, curdir, met2utc
+from .batlib import dirtest, met2utc
 from .bat_survey import MosaicBatSurvey
 import numpy as np
 from astropy.time import Time
-import os
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from astropy import units as u
@@ -27,7 +25,6 @@ except ModuleNotFoundError as err:
     print(err)
 
 import swiftbat.swutil as sbu
-
 
 # Off-axis flux correction file
 _cimgfile = "offaxiscorr_8bin_20061221.img"
@@ -62,7 +59,7 @@ _sco_coord = SkyCoord(_scox1_ra, _scox1_dec, frame="icrs", unit="deg")
 
 def interp_weights(xyz, uvw, d=2):
     """
-    This is a funciton to calculate the weights for each vertex on a grid that will be interpolated
+    This is a function to calculate the weights for each vertex on a grid that will be interpolated
     over. See https://stackoverflow.com/questions/20915502/speedup-scipy-griddata-for-multiple-interpolations-between-two-irregular-grids
 
     :param xyz: The x,y,z points that will be interpolated over on the new grid
@@ -274,7 +271,7 @@ def merge_outventory(survey_list, savedir=None):
         "outventory_all.fits"
     )
 
-    shutil.copy(survey_list[0].result_dir.joinpath("stats_point.fits"),output_file)
+    shutil.copy(survey_list[0].result_dir.joinpath("stats_point.fits"), output_file)
     for i in survey_list[1:]:
         with fits.open(output_file) as hdul1:
             with fits.open(i.result_dir.joinpath("stats_point.fits")) as hdul2:
@@ -286,7 +283,7 @@ def merge_outventory(survey_list, savedir=None):
                     hdu.data[colname][nrows1:] = hdul2[1].data[colname]
                 hdu.writeto(output_file, overwrite=True)
 
-    #now sort the file by time
+    # now sort the file by time
     with fits.open(output_file, mode="update") as hdul:
         hdu = hdul[1]
         idx = np.argsort(hdu.data['TSTART'])
@@ -309,15 +306,15 @@ def select_outventory(outventory_file, start_met, end_met):
     :return: None
     """
 
-    #replace the ftselect with astropy fits operations
+    # replace the ftselect with astropy fits operations
     output_file = str(outventory_file).replace(".fits", "_sel.fits")
     with fits.open(outventory_file) as f:
-        #identify the lines with the times of interest/images that are good and have the comparison be broadcastable
+        # identify the lines with the times of interest/images that are good and have the comparison be broadcastable
         idx = np.where(
             (f[1].data["TSTART"][..., None] >= start_met) & (f[1].data["TSTART"][..., None] < end_met) &
             (f[1].data["IMAGE_STATUS"][..., None] == True))
 
-        #save the headers of the original outventory file and then copy them to the new output file
+        # save the headers of the original outventory file and then copy them to the new output file
         hdu = f[1]
         hdu.data = hdu.data[idx[0]]
         hdu.writeto(output_file)
@@ -343,45 +340,46 @@ def group_outventory(
     :param start_datetime: An astropy Time object that denotes the start date to start binning the observations
     :param end_datetime: An astropy Time object that denotes the end date to stop binning the observations
     :param recalc: Boolean to denote if the directoruy at is created or not. Also denotes if the
-    :param mjd_savedir: Boolean to denote if the directory of the created directory has the datetime64 with the start date
-        of the beginning of the timebin of interest or if the directory name is formatted with mjd time (which is useful
-        for mosaicing with timebins shorter than a day)
+    :param mjd_savedir: Boolean to denote if the directory of the created directory has the datetime64 with the start
+        date of the beginning of the timebin of interest or if the directory name is formatted with mjd time
+        (which is useful for mosaicing with timebins shorter than a day)
     :param custom_timebins: None OR
         an array of astropy Time values denoting the timebin edges for which mosaicing will take place.
-            ie if custom_timebins=astropy.Time(["2022-10-08","2022-10-10", "2022-10-12"]) then there will be 2 grouped outventory files
-            (and thus mosaics) will be created.
-        OR a list of N astropy Time arrays each with shape (2 x T) where N grouped outventory files will be created (and thus
-        mosaics will be created) where the selected observation times correspond to the time bin edges denoted by the single
-        (2 x T) array. The astropy Time array should be formatted such that row 0 (indexed as [0,:]) contains all the
-        start times of the edges of the timebins of interest which will be mosaiced together. The row 1 of the astropy
-        Time array (indexed as [1,:]) contains all the end times of the edges of the timebins of interest which will be mosaiced together.
+            ie if custom_timebins=astropy.Time(["2022-10-08","2022-10-10", "2022-10-12"]) then there will be 2 grouped
+            outventory files (and thus mosaics) will be created.
+        OR a list of N astropy Time arrays each with shape (2 x T) where N grouped outventory files will be created
+        (and thus mosaics will be created) where the selected observation times correspond to the time bin edges
+        denoted by the single (2 x T) array. The astropy Time array should be formatted such that row 0
+        (indexed as [0,:]) contains all the start times of the edges of the timebins of interest which will be mosaiced
+        together. The row 1 of the astropy Time array (indexed as [1,:]) contains all the end times of the edges of the
+        timebins of interest which will be mosaiced together.
             ie if tbins=[
                 Time([["2022-10-08","2022-10-11"],
                     ["2022-10-10", "2022-10-12"]]),
                 Time([["2022-10-10"],
                     ["2022-10-11"]])]
 
-                then there will be 2 mosaics created. Mosaic 1 will combine observations from 2022-10-08 to 2022-10-10 AND observations
-                from 2022-10-11 to 2022-10-12. While mosaic 2 will combine observations from 2022-10-10 to
-                2022-10-11.
-    :param save_group_outventory: a Boolean that denotes whether the grouped outventory files for each time bin and the associated
-        directories to hold the mosaic results for the time bins will be created. If this is set to False, these will
-        not be created but the calculated time_bins will be returned
-    :return: astropy Time array of the time bin edges that are created based on the user specification. This can be passed directly
-        to the create_mosaic function.
+                then there will be 2 mosaics created. Mosaic 1 will combine observations from 2022-10-08 to 2022-10-10
+                AND observations from 2022-10-11 to 2022-10-12.
+                While mosaic 2 will combine observations from 2022-10-10 to 022-10-11.
+    :param save_group_outventory: a Boolean that denotes whether the grouped outventory files for each time bin and the
+        associated directories to hold the mosaic results for the time bins will be created. If this is set to False,
+        these will not be created but the calculated time_bins will be returned
+    :return: astropy Time array of the time bin edges that are created based on the user specification. This can be
+        passed directly to the create_mosaic function.
     """
 
     # need to group the observations based on the time binning that the user wants this is given by binning_timedelta
-    # we can start from the first entry of the time sorted outventory file (or the start datetime that the user specifies)
-    # and go until the end of the last observation of the outventory file (or the end datetime that the user specifies)
+    # we can start from the first entry of the time sorted outventory file (or the start datetime that the user
+    # specifies) and go until the end of the last observation of the outventory file (or the end datetime that the
+    # user specifies)
 
     # error checking
 
-    #if the  custom_timebins variable is set to none (the default) then we defualt to using the start/end_datetimes so need
-    # to do input checks here
-    #also set this time_bins_is_list switch to false by default
+    # if the  custom_timebins variable is set to none (the default) then we defualt to using the start/end_datetimes
+    # so need to do input checks here also set this time_bins_is_list switch to false by default
     time_bins_is_list = False
-    if  custom_timebins is None:
+    if custom_timebins is None:
         if type(binning_timedelta) is not np.timedelta64:
             raise ValueError(
                 "The binning_timedelta variable needs to be a numpy timedelta64 object."
@@ -403,9 +401,9 @@ def group_outventory(
     else:
         if type(custom_timebins) is not Time and type(custom_timebins) is not list:
                 raise ValueError(
-                    "The  custom_timebins variable needs to be an astropy Time object or a list of astropy Time objects."
+                    "The custom_timebins variable needs to be an astropy Time object or a list of astropy Time objects."
                 )
-        #make sure that all elements of list are astropy time objects and set a switch for later processing
+        # make sure that all elements of list are astropy time objects and set a switch for later processing
         if type(custom_timebins) is list:
             for i in custom_timebins:
                 if type(i) is not Time:
@@ -415,14 +413,13 @@ def group_outventory(
                     )
             time_bins_is_list=True
 
-
     # initalize the reference time for the Swift MET time (starts from 2001), used to calculate MET
     reference_time = Time("2001-01-01")
 
     # make sure its a path object
     outventory_file = Path(outventory_file)
 
-    #if we dont have the actual time bins passed in we need to calcualte them
+    # if we dont have the actual time bins passed in we need to calcualte them
     if custom_timebins is None:
         # by default use the earliest date of outventory file
         if start_datetime is None:
@@ -441,11 +438,11 @@ def group_outventory(
                 tholder[i] = 0
             start_datetime = Time(tholder)
 
-        # by default use the last entry of the outventory_file rounded to the nearest timedelta that the user is interested in
+        # by default use the last entry of the outventory_file rounded to the nearest timedelta that the user is
+        # interested in
         if end_datetime is None:
             with fits.open(outventory_file) as f:
                 end_datetime = Time(met2utc(f[1].data["TSTART"].max()))
-
 
         if binning_timedelta == np.timedelta64(1, "M"):
             # if the user wants months, need to specify each year, month and the number of days
@@ -497,23 +494,22 @@ def group_outventory(
         # convert to astropy time objects
         time_bins = Time(time_bins)
     else:
-        #need to convert the  custom_timebins to the time_bins format which is trivial since they are already set to be that
-        time_bins =  custom_timebins
+        # need to convert the  custom_timebins to the time_bins format which is trivial since they are already set to
+        # be that
+        time_bins = custom_timebins
 
-    #need to see if time_bins is a 1D Time array or a list of size N where there are N arrays of dimension 2xT where
+    # need to see if time_bins is a 1D Time array or a list of size N where there are N arrays of dimension 2xT where
     # there are T time bins of interest that will be combined into a grouped outventory file. The index 0 of the T
     # times should be the start of the time bin(s) of interest while the index 1 of the T times should be the end of
     # the time bins
 
-
-
-    #if we want to create the timebin mosaic directories and the associated group outventory do so, otherwise just
+    # if we want to create the timebin mosaic directories and the associated group outventory do so, otherwise just
     # return the time_bins for the user to check them
     if save_group_outventory:
-        # creazte the folder that will hold the ouventory files for each time range of interest
+        # create the folder that will hold the outventory files for each time range of interest
         savedir = outventory_file.parent.joinpath(
             "grouped_outventory"
-        )  # os.path.join(os.path.split(outventory_file)[0], "grouped_outventory")
+        )
 
         # see if the savedir exists, if it does, then we dont have to do all of these calculations again
         if not savedir.exists() or recalc:
@@ -536,10 +532,8 @@ def group_outventory(
                     end = time_bins[i + 1]
 
                     # convert from utc times to mjd and then from mjd to MET
-                   # t = Time(start)
                     start_met = sbu.datetime2met(start.datetime, correct=True)
 
-                    #t = Time(end)
                     end_met = sbu.datetime2met(end.datetime, correct=True)
                 else:
                     start = time_bins[i][0,0]
@@ -554,7 +548,7 @@ def group_outventory(
                 select_outventory(outventory_file, start_met, end_met)
 
                 if time_bins_is_list:
-                    #after selecting the array of times for the grouped outventory when we have a list passed in
+                    # after selecting the array of times for the grouped outventory when we have a list passed in
                     # we need to set start_met and end_met to a single value for updating the header values
                     start_met = start_met[0]
                     end_met = end_met[0]
@@ -574,7 +568,6 @@ def group_outventory(
                         )
                     )
 
-                # os.system("mv %s %s" % (output_file, savefile))
                 output_file.rename(savefile)
 
                 with fits.open(str(savefile), mode="update") as file:
@@ -589,7 +582,6 @@ def group_outventory(
                     file.flush()
 
                 # create the directories that will hold all the mosaiced images within a given time bin
-                # binned_savedir = os.path.join(os.path.split(outventory_file)[0], 'mosaic_'+str(start.astype('datetime64[D]')))
                 if not mjd_savedir:
                     binned_savedir = outventory_file.parent.joinpath(
                         f"mosaic_{start.datetime64.astype('datetime64[D]')}"
@@ -616,7 +608,6 @@ def read_skygrids(savedirectory=None):
     # reads the skygrids and output numpy array that contains all the data
 
     # get the directory that the data directory is located in
-    # dir = os.path.split(__file__)[0]
     if savedirectory is None:
         dir = Path(__file__).parent
     else:
@@ -643,10 +634,10 @@ def read_skygrids(savedirectory=None):
 
         ra_file = dir.joinpath("data").joinpath(
             ra_string
-        )  # os.path.join(dir, "data", ra_string)
+        )
         dec_file = dir.joinpath("data").joinpath(
             dec_string
-        )  # os.path.join(dir, "data", dec_string)
+        )
 
         file = fits.open(str(ra_file))
         ra_skygrid[:, :, i] = file[0].data
@@ -673,10 +664,10 @@ def convert_radec2xy(ra, dec, header):
     # make the WCS object
     w = WCS(header)
 
-    # calcualte the xy values, think I need to use origin=0 because in fits header says that initial pixel is 0? not sure
-    # need to double check against idl code. When comparing wcs_world2pix to heasarc sky2xy, the results of sky2xy
-    # matches with wcs_world2pix if we use origin=1, therefore we probably need this since the codes had typically
-    # used heasarc scripts
+    # calculate the xy values, think I need to use origin=0 because in fits header says that initial pixel is 0? not
+    # sure need to double-check against idl code. When comparing wcs_world2pix to heasarc sky2xy, the results of
+    # sky2xy matches with wcs_world2pix if we use origin=1, therefore we probably need this since the codes had
+    # typically used heasarc scripts
     xy = w.wcs_world2pix(np.array([ra.flatten(), dec.flatten()], dtype="float64").T, 0)
 
     # reshape to be the original dimensions of the ra/dec arrays
@@ -692,7 +683,8 @@ def convert_xy2radec(x, y, header):
 
     :param x: numpy array of pixel x coordinates
     :param y: numpy array of pixel y coordinates
-    :param header: The header that will be used to extract astrometric keywords to convert RA/DEC to detector pixel coordinates
+    :param header: The header that will be used to extract astrometric keywords to convert RA/DEC to detector pixel
+        coordinates
     :return: numpy arrays of RA/DEC in degrees
     """
     # use the astropy WCS object to convert from x,y to ra and dec
@@ -700,7 +692,8 @@ def convert_xy2radec(x, y, header):
     # make the WCS object
     w = WCS(header)
 
-    # calcualte the ra/dec values, think I need to use origin=0 because in fits header says that initial pixel is 0? not sure
+    # calculate the ra/dec values, think I need to use origin=0 because in fits header says that initial pixel is 0?
+    # not sure
     ra_dec = w.wcs_pix2world(np.array([x.flatten(), y.flatten()], dtype="float64").T, 0)
 
     # reshape to be the original dimensions of the ra/dec arrays
@@ -708,30 +701,28 @@ def convert_xy2radec(x, y, header):
     dec = ra_dec[:, 1].reshape(y.shape)
 
     if "galactic" in w.world_axis_physical_types[0]:
-        # converted cooordinates in galactic coordinates and need to convert to RA/DEC
+        # converted coordinates in galactic coordinates and need to convert to RA/DEC
         c = SkyCoord(l=ra, b=dec, frame="galactic", unit="deg")
         ra = c.fk5.ra.value
         dec = c.fk5.dec.value
 
     return ra, dec
 
-
 def read_correctionsmap():
     """
-    Reads the BAT coded mask energy-dependent off axis corrections mask which accounts for the fact that the mask has a finite width
-    which affects the propagation of photons at some angle relative to the boresight.
+    Reads the BAT coded mask energy-dependent off axis corrections mask which accounts for the fact that the mask has a
+    finite width which affects the propagation of photons at some angle relative to the boresight.
 
     :return: numpy array of (954, 1760, _nebands) where _nebands=8, which is the number of energy bands in the BAT survey
     """
     # reads the correction map for correcting off-axis effects
 
     # get the directory that the data directory is located in
-    # dir = os.path.split(__file__)[0]
     dir = Path(__file__).parent
 
     file_string = dir.joinpath("data").joinpath(
         _cimgfile
-    )  # os.path.join(dir, "data", _cimgfile)
+    )
 
     # create array to hold data, already know sizes of grids from looking at file
     corrections_map = np.zeros((954, 1760, _nebands))
@@ -789,7 +780,7 @@ def compute_statistics_map(chi_sq, nbatdet, ra_pnt, dec_pnt, pa_pnt, tstart):
     coord_array = SkyCoord(ra_pnt, dec_pnt, frame="icrs", unit="deg")
     ang_sep = coord_array.separation(_sco_coord)  # these are in degrees
 
-    # calcualate the extra chisq value added around Sco X-1 for the lowest energy band
+    # calculate the extra chisq value added around Sco X-1 for the lowest energy band
     sco_xtra_chi2 = scox1_slop(ang_sep.value)
 
     # stop
@@ -806,7 +797,7 @@ def compute_statistics_map(chi_sq, nbatdet, ra_pnt, dec_pnt, pa_pnt, tstart):
                 mask & (red_chi2[:, i] > _chilothresh) & (red_chi2[:, i] < _chihithresh)
             )
 
-    # include whether Sco is the object corresponsind to the pointing. If it is, we want to exclude this poinitng ID,
+    # include whether Sco is the object corresponding to the pointing. If it is, we want to exclude this pointing ID,
     # therefore set mask=0
     idx = np.where(
         (ra_pnt > 245)
@@ -848,7 +839,6 @@ def write_mosaic(
     filename_base = Path(filename_base)
 
     # get the directory that the data directory is located in
-    # direc = os.path.split(__file__)[0]
     direc = Path(Path(__file__).parent)
 
     # get the current date_time
@@ -899,9 +889,6 @@ def write_mosaic(
         with fits.open(str(ra_file)) as file:
             skygrid_header = file[0].header
 
-        # get rid of this old date in the old skyfacets. Now that we create them when batanalysis is imported for the first
-        # time ever, the created files dont have this header value
-        # skygrid_header.remove('DATE')
         total_header = header + add_header + skygrid_header
         total_header["BSKYPLAN"] = (string, "BAT mosaic ZEA sky plane ID (0-5)")
 
@@ -959,8 +946,6 @@ def finalize_mosaic(intermediate_mosaic_directory):
         string = "c%d_%s" % (i, _proj)
 
         # copy the expmap to the new name and remove a few header keywords
-        # file_name=os.path.join(intermediate_mosaic_directory, f'expmap_{string}.img')
-        # output_name=os.path.join(intermediate_mosaic_directory, f'swiftbat_flatexp_c{i}.img')
         file_name = intermediate_mosaic_directory.joinpath(f"expmap_{string}.img")
         output_name = intermediate_mosaic_directory.joinpath(
             f"swiftbat_flatexp_c{i}.img"
@@ -976,8 +961,6 @@ def finalize_mosaic(intermediate_mosaic_directory):
             file.flush()
 
         # do the same for the pcode file
-        # file_name=os.path.join(intermediate_mosaic_directory, f'pcode_{string}.img')
-        # output_name=os.path.join(intermediate_mosaic_directory, f'swiftbat_exposure_c{i}.img')
         file_name = intermediate_mosaic_directory.joinpath(f"pcode_{string}.img")
         output_name = intermediate_mosaic_directory.joinpath(
             f"swiftbat_exposure_c{i}.img"
@@ -994,8 +977,6 @@ def finalize_mosaic(intermediate_mosaic_directory):
 
         # for the flux, need to do simg/vimg and save this for each sky image and energy band
         # and change some of the header keywords
-        # flux_file_name=os.path.join(intermediate_mosaic_directory, f'flux_{string}.img')
-        # flux_output_name=os.path.join(intermediate_mosaic_directory, f'swiftbat_flux_c{i}.img')
         flux_file_name = intermediate_mosaic_directory.joinpath(f"flux_{string}.img")
         flux_output_name = intermediate_mosaic_directory.joinpath(
             f"swiftbat_flux_c{i}.img"
@@ -1004,18 +985,14 @@ def finalize_mosaic(intermediate_mosaic_directory):
 
         # for the SNR, need to do simg/sqrt(vimg) and save this for each sky image and energy band
         # and change some of the header keywords
-        # snr_file_name=os.path.join(intermediate_mosaic_directory, f'flux_{string}.img')
-        # snr_output_name=os.path.join(intermediate_mosaic_directory, f'swiftbat_snr_c{i}.img')
         snr_file_name = intermediate_mosaic_directory.joinpath(f"flux_{string}.img")
         snr_output_name = intermediate_mosaic_directory.joinpath(
             f"swiftbat_snr_c{i}.img"
         )
         shutil.copy(snr_file_name, snr_output_name)
 
-        # after calcualting the flux and the SNR, for the variance, need to convert from units of (1/cts/s)^2) to cts/s
+        # after calculating the flux and the SNR, for the variance, need to convert from units of (1/cts/s)^2) to cts/s
         # and modify the header
-        # var_file_name=os.path.join(intermediate_mosaic_directory, f'var_{string}.img')
-        # var_output_name=os.path.join(intermediate_mosaic_directory, f'swiftbat_var_c{i}.img')
         var_file_name = intermediate_mosaic_directory.joinpath(f"var_{string}.img")
         var_output_name = intermediate_mosaic_directory.joinpath(
             f"swiftbat_var_c{i}.img"
@@ -1099,17 +1076,17 @@ def create_mosaics(
         be used to create the mosaiced images.
     :param time_bins: The time bins that the observatons in outventory file have been grouped into
     :param survey_list: The list of BATSurvey objects that correpond to the observations listed in the outventory file
-    :param catalog_file: A Path object of the catalog file that should be used to identify sources in the mosaic images. This
-        will default to using the catalog file that is included with the BatAnalysis package.
-    :param total_mosaic_savedir: Default None or a Path object that denotes the directory that the total "time-integrated"
-        images will be saved to. The default is to place the total mosaic image in a directory called "total_mosaic"
-        located in the same directory as the outventory file.
-    :param recalc: Boolean False by default. If this calculation was done previously, do not try to load the results of prior calculations. Instead
-        recalculate the mosaiced images. The default, will cause the function to try to load a save file to save on computational
-        time.
+    :param catalog_file: A Path object of the catalog file that should be used to identify sources in the mosaic images.
+        This will default to using the catalog file that is included with the BatAnalysis package.
+    :param total_mosaic_savedir: Default None or a Path object that denotes the directory that the total
+        "time-integrated" images will be saved to. The default is to place the total mosaic image in a directory called
+        "total_mosaic" located in the same directory as the outventory file.
+    :param recalc: Boolean False by default. If this calculation was done previously, do not try to load the results of
+        prior calculations. Instead recalculate the mosaiced images. The default, will cause the function to try to load
+        a save file to save on computational time.
     :param verbose: Boolean True by default. Tells the code to print progress/diagnostic information.
-    :return: a list of MosaicBatSurvey objects correponding to each time bin that was requested, and a single MosaicBatSurvey
-        corresponding to the total mosaiced image across all time bins.
+    :return: a list of MosaicBatSurvey objects correponding to each time bin that was requested, and a single M
+        osaicBatSurvey corresponding to the total mosaiced image across all time bins.
     """
     # This function actually creates the mosaic-ed files, NOTE there is no usco inclusion here, but this can be
     # easily added if its really necessary. In the idl code, it didnt seem like this was used, but not sure.
@@ -1171,8 +1148,8 @@ def create_mosaics(
 
     intermediate_mosaic_dir_list = [i.result_dir for i in all_mosaic_survey]
 
-    # see if the total mosaic has been created and saved (ie there is a .batsurvey file in that directory) if there isnt,
-    # then do the full calculation or if we set recalc=True then also do the full calculation
+    # see if the total mosaic has been created and saved (ie there is a .batsurvey file in that directory) if there
+    # isnt, then do the full calculation or if we set recalc=True then also do the full calculation
     if total_mosaic_savedir is None:
         total_mosaic_savedir = intermediate_mosaic_dir_list[0].parent.joinpath(
             "total_mosaic"
@@ -1181,7 +1158,8 @@ def create_mosaics(
         total_mosaic_savedir = Path(total_mosaic_savedir)
 
     if not total_mosaic_savedir.joinpath("batsurvey.pickle").exists() or recalc:
-        # merge all the mosaics together to get the full 'time integrated' images and convert to final files with proper units
+        # merge all the mosaics together to get the full 'time integrated' images and convert to final files with
+        # proper units
         total_dir = merge_mosaics(
             intermediate_mosaic_dir_list, savedir=total_mosaic_savedir
         )
@@ -1217,8 +1195,8 @@ def _mosaic_loop(
      the flux is multiplied by the summed inverse variance image
      the inverse variance image is converted back to normal variance.
 
-    :param outventory_file: Path object that provides the full outventory file of the BAT survey observations that will be
-        used to calculate the mosaiced images.
+    :param outventory_file: Path object that provides the full outventory file of the BAT survey observations that will
+        be used to calculate the mosaiced images.
     :param start: astropy Time of the start time of the time bin that survey observations need to be made to be included
         in that time bin's mosaiced image.
     :param end: astropy Time of the end time of the time bin that survey observations need to be made to be included
@@ -1241,10 +1219,10 @@ def _mosaic_loop(
     # get the name of the file with binned outventory info and where its saved
     savedir = outventory_file.parent.joinpath(
         "grouped_outventory"
-    )  # os.path.join(os.path.split(outventory_file)[0], "grouped_outventory")
+    )
     output_file = savedir.joinpath(
         outventory_file.name.replace(".fits", f"_{start.datetime64.astype('datetime64[D]')}.fits")
-    )  # os.path.join(savedir, os.path.split(outventory_file)[-1].replace(".fits", "_"+str(start.astype('datetime64[D]'))+".fits"))
+    )
     #see if we need to use the mjd time format
     if not output_file.exists():
         output_file = savedir.joinpath(
@@ -1254,7 +1232,7 @@ def _mosaic_loop(
     # this is the directory of the time bin where the images will be saved
     img_dir = outventory_file.parent.joinpath(
         f"mosaic_{start.datetime64.astype('datetime64[D]')}"
-    )  # os.path.join(os.path.split(outventory_file)[0],'mosaic_'+str(start.astype('datetime64[D]')))
+    )
     if not img_dir.exists():
         img_dir = outventory_file.parent.joinpath(
             f"mosaic_{start.mjd}"
@@ -1309,9 +1287,7 @@ def _mosaic_loop(
             obsid = grouped_outventory_data["OBS_ID"][j]
             pointing_id = grouped_outventory_data["IMAGE_ID"][j]
 
-            # test that we have good image statistics, put FALSE for testing, uncomment next two lines to go back to orig
-            # if False:
-            # stop
+            # test that we have good image statistics
             if (
                 (chi_mask[j] == 0)
                 or (grouped_outventory_data["NBATDETS"][j] <= 0)
@@ -1341,7 +1317,7 @@ def _mosaic_loop(
 
                     data_directory = batsurvey_result_dir.joinpath(
                         pointing_id
-                    )  # os.path.join(batsurvey_result_dir, pointing_id)
+                    )
 
                     ncleaniter = survey_list[surveylist_idx].batsurvey_result.params[
                         "ncleaniter"
@@ -1350,7 +1326,7 @@ def _mosaic_loop(
                     # read the partial coding map, variance map, sky flux map for the pointing
                     pointing_pimg_str = data_directory.joinpath(
                         f"{pointing_id}_{ncleaniter}.img"
-                    )  # os.path.join(data_directory, pointing_id+"_"+ncleaniter+".img")
+                    )
                     with fits.open(str(pointing_pimg_str)) as file:
                         # read the partial coding map
                         pointing_pimg = file["BAT_PCODE_1"].data
@@ -1381,7 +1357,7 @@ def _mosaic_loop(
                         pointing_vimg = np.zeros_like(pointing_simg)
                         pointing_vimg_str = data_directory.joinpath(
                             f"{pointing_id}_{ncleaniter}.var"
-                        )  # os.path.join(data_directory, pointing_id+"_"+ncleaniter+".var")
+                        )
                         with fits.open(str(pointing_vimg_str)) as file:
                             for k in range(_nebands):
                                 pointing_vimg[:, :, k] = file[k].data
@@ -1405,12 +1381,6 @@ def _mosaic_loop(
 
                         # construct the quality map for each energy and for the total energy images
                         energy_quality_mask = np.zeros_like(pointing_vimg_corr)
-                        # for k in range(pointing_vimg_corr.shape[-1]):
-                        #    good_idx=np.where((pointing_pimg > _pcodethresh) & (pointing_vimg_corr[:,:,k] > 0) &\
-                        #                      np.isfinite(pointing_simg_corr[:,:,k]) & np.isfinite(pointing_vimg_corr[:,:,k]))
-                        #    energy_quality_mask[:,:,k][good_idx]=1
-
-                        # without a for loop, can try: Verified that this works the same as above for loop
                         good_idx = np.where(
                             (
                                 np.repeat(
@@ -1426,8 +1396,7 @@ def _mosaic_loop(
                         )
                         energy_quality_mask[good_idx] = 1
 
-                        # make the intermediate maps for each energy and for the total energy (need to double check that
-                        # broadcasting is correct)
+                        # make the intermediate maps for each energy and for the total energy
                         interm_pointing_eimg = (
                             energy_quality_mask * pointing_exposure
                         )  # Exposure map
@@ -1451,8 +1420,8 @@ def _mosaic_loop(
                             ra_skygrid, dec_skygrid, pointing_pimg_header
                         )
 
-                        # get the good values, in the idl file the shape of pointing_pimg is reversed, not sure if this is correct
-                        # here.
+                        # get the good values, in the idl file the shape of pointing_pimg is reversed, not sure if
+                        # this is correct here.
                         pixel_idx = np.where(
                             (pixel_y <= pointing_pimg.shape[0])
                             & (pixel_x <= pointing_pimg.shape[1])
@@ -1474,10 +1443,9 @@ def _mosaic_loop(
                         values = interm_pointing_eimg[:, :, 0]
                         values[np.isnan(values)] = 0
 
-                        # before had: #np.array([chosen_pixel_x, chosen_pixel_y]) for the below line but the
-                        # results werent consistent with the idl code results. changing the x and y pixel coordinates here works
+                        # before had: #np.array([chosen_pixel_x, chosen_pixel_y]) for the below line but the results
+                        # werent consistent with the idl code results. changing the x and y pixel coordinates here works
                         interp_at_points = np.array([chosen_pixel_y, chosen_pixel_x])
-                        # eimg[pixel_idx] += griddata(points.T, values.flatten(), interp_at_points.T, rescale=True, fill_value=0)
 
                         # see if thie other method works,
                         # https://stackoverflow.com/questions/20915502/speedup-scipy-griddata-for-multiple-interpolations-between-two-irregular-grids
@@ -1487,56 +1455,32 @@ def _mosaic_loop(
                             pixel_idx
                         ] += test  # new interpolate dir, took 722.239518339 s
 
-                        # see if method here works
+                        # tried if method here works
                         # https://stackoverflow.com/questions/51858194/storing-the-weights-used-by-scipy-griddata-for-re-use/51937990#51937990
-                        # tri = Delaunay(points.T)  # Compute the triangulation
-                        # Perform the interpolation with the given values:
-                        # interpolator = LinearNDInterpolator(tri, values.flatten())
-                        # values_mesh2 = interpolator(interp_at_points.T)
-                        # eimg[pixel_idx] += values_mesh2 #new interpolate 2 dir, took 3247.2622033880034 s
-                        # stop
+                        # found that it took 3247.2622033880034 s versus 722.239518339 s
 
                         values = interm_pointing_pimg[:, :, 0]
                         values[
                             np.isnan(values)
                         ] = 0  # if there are nan values in the images, this can mess up the interpolation
-                        # pimg[pixel_idx] += griddata(points.T, values.flatten(), interp_at_points.T, rescale=True, fill_value=0)
 
-                        # see if thie other method works,
                         test = interpolate(values.flatten(), vtx, wts, fill_value=0)
-                        pimg[pixel_idx] += test  # new interpolate dir
+                        pimg[pixel_idx] += test
 
-                        # see if method here works
-                        # interpolator = LinearNDInterpolator(tri, values.flatten())
-                        # values_mesh2 = interpolator(interp_at_points.T)
-                        # pimg[pixel_idx] += values_mesh2  # new interpolate 2 dir
 
                         for k in range(_nebands + 1):
                             values = interm_pointing_simg[:, :, k]
                             values[np.isnan(values)] = 0
-                            # simg[:, :, :, k][pixel_idx]+=griddata(points.T, values.flatten(), interp_at_points.T, rescale=True, fill_value=0)
 
-                            # see if thie other method works,
                             test = interpolate(values.flatten(), vtx, wts, fill_value=0)
                             simg[:, :, :, k][pixel_idx] += test  # new interpolate dir
 
-                            # see if method here works
-                            # interpolator = LinearNDInterpolator(tri, values.flatten())
-                            # values_mesh2 = interpolator(interp_at_points.T)
-                            # simg[:, :, :, k][pixel_idx] += values_mesh2  # new interpolate 2 dir
-
                             values = interm_pointing_vimg[:, :, k]
                             values[np.isnan(values)] = 0
-                            # vimg[:, :, :, k][pixel_idx]+=griddata(points.T, values.flatten(), interp_at_points.T, rescale=True, fill_value=0)
 
-                            # see if thie other method works,
                             test = interpolate(values.flatten(), vtx, wts, fill_value=0)
                             vimg[:, :, :, k][pixel_idx] += test  # new interpolate dir
 
-                            # see if method here works
-                            # interpolator = LinearNDInterpolator(tri, values.flatten())
-                            # values_mesh2 = interpolator(interp_at_points.T)
-                            # vimg[:, :, :, k][pixel_idx] += values_mesh2  # new interpolate 2 dir
 
                         # keep track of exposure and times
                         total_binned_exposure += pointing_exposure
@@ -1552,8 +1496,6 @@ def _mosaic_loop(
         # if there were no files that were mosaiced for the time interval dont copy any of the template fits files
         # to save space, also dont include these time bins in the total mosaic calculation
         if len(merged_pointing_dir) > 0:
-            # also save the directory with the valid mosaic-ed images
-            # intermediate_mosaic_dir_list.append(img_dir)
 
             # need to write the outputs after combining datasets that fall within a time bin
             # create a model header
@@ -1570,7 +1512,6 @@ def _mosaic_loop(
                 "py" + pkg_resources.require("BatAnalysis")[0].version,
                 " BAT mosaic processing version",
             )
-            # model_hdr['BMOSPLT']=(platform,     ' BAT mosaic processing platform') #dont need this defined? NO see finalize_mosaic where it would be removed anyway
             model_hdr["BMOSMON"] = (
                 str(start.datetime64.astype("datetime64[D]")),
                 " BAT mosaic processing date",
@@ -1609,10 +1550,8 @@ def _mosaic_loop(
             )
 
             # Add info about the user specified TBIN that was used to create the mosaic
-            #t = Time(start)
             start_met = sbu.datetime2met(start.datetime)
 
-            #t = Time(end)
             end_met = sbu.datetime2met(end.datetime)
 
             model_hdr["S_TBIN"] = (start_met, "Mosaicing Start of Time Bin (MET)")
@@ -1667,7 +1606,6 @@ def _mosaic_loop(
             # create a mosaic survey object to hold all the information and allow the user to
             mosaic_survey = MosaicBatSurvey(img_dir)
             mosaic_survey.save()
-            # all_mosaic_survey.append(mosaic_survey)
         else:
             mosaic_survey = None
     else:
@@ -1694,10 +1632,10 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
     if savedir is None:
         savedir = intermediate_mosaic_dir_list[
             0
-        ].parent  # os.path.split(intermediate_mosaic_dir_list[0])[0]
+        ].parent
         total_dir = savedir.joinpath(
             "total_mosaic"
-        )  # os.path.join(savedir, 'total_mosaic')
+        )
     else:
         total_dir = savedir
 
@@ -1731,11 +1669,12 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
             # open the pimg and add it to the array and accumulate the exposure and other header info
             pimg_file = i.joinpath(
                 "pcode_" + string + ".img"
-            )  # os.path.join(i, 'pcode_'+string+ '.img')
+            )
             with fits.open(str(pimg_file)) as file:
                 # read the partial coding map
                 pimg[:, :, j] += file[0].data
-                # for the first sky facet obtain this info. all sky facets have this info so we only need it from one sky facet
+                # for the first sky facet obtain this info. all sky facets have this info so we only need it from one
+                # sky facet
                 if j == 0:
                     total_binned_exposure += file[0].header["EXPOSURE"]
                     total_tstart.append(file[0].header["TSTART"])
@@ -1748,7 +1687,7 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
             # open the eimg and add it to the array and accumulate the exposure
             eimg_file = i.joinpath(
                 "expmap_" + string + ".img"
-            )  # os.path.join(i, 'expmap_' + string + '.img')
+            )
             with fits.open(str(eimg_file)) as file:
                 # read the flat exposure map
                 eimg[:, :, j] += file[0].data
@@ -1756,10 +1695,10 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
             # open the vimg and flux files
             simg_file_name = i.joinpath(
                 "flux_" + string + ".img"
-            )  # os.path.join(i, 'flux_' + string + '.img')
+            )
             vimg_file_name = i.joinpath(
                 "var_" + string + ".img"
-            )  # os.path.join(i, 'var_' + string + '.img')
+            )
 
             simg_file = fits.open(str(simg_file_name))
             vimg_file = fits.open(str(vimg_file_name))
@@ -1773,9 +1712,9 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
             simg_file.close()
             vimg_file.close()
 
-    # after adding everything up, need to save the data
-    # to save time/effort just copy over some of the intermediate files from the 0th directory of the list that is passed
-    # in, into the total_mosaic directory and update these data/header values
+    # after adding everything up, need to save the data to save time/effort just copy over some of the intermediate
+    # files from the 0th directory of the list that is passed in, into the total_mosaic directory and update these
+    # data/header values
 
     tmin = np.min(total_tstart)
     tmax = np.max(total_tstop)
@@ -1790,8 +1729,6 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
         string = "c%d_%s" % (j, _proj)
 
         # do this for the exposure
-        # file_name=os.path.join(intermediate_mosaic_dir_list[0], f'expmap_{string}.img')
-        # output_name=os.path.join(total_dir, f'expmap_{string}.img')
         file_name = intermediate_mosaic_dir_list[0].joinpath(f"expmap_{string}.img")
         output_name = total_dir.joinpath(f"expmap_{string}.img")
         shutil.copy(file_name, output_name)
@@ -1813,9 +1750,6 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
             file.flush()
 
         # do this for the pcode
-        # file_name=os.path.join(intermediate_mosaic_dir_list[0], f'pcode_{string}.img')
-        # output_name=os.path.join(total_dir, f'pcode_{string}.img')
-        # input=dict(infile=file_name, outfile=output_name)
         file_name = intermediate_mosaic_dir_list[0].joinpath(f"pcode_{string}.img")
         output_name = total_dir.joinpath(f"pcode_{string}.img")
         shutil.copy(file_name, output_name)
@@ -1837,16 +1771,10 @@ def merge_mosaics(intermediate_mosaic_dir_list, savedir=None):
             file.flush()
 
         # copy files for the variability and flux
-        # file_name=os.path.join(intermediate_mosaic_dir_list[0], f'var_{string}.img')
-        # var_output_name=os.path.join(total_dir, f'var_{string}.img')
-        # input=dict(infile=file_name, outfile=var_output_name)
         file_name = intermediate_mosaic_dir_list[0].joinpath(f"var_{string}.img")
         var_output_name = total_dir.joinpath(f"var_{string}.img")
         shutil.copy(file_name, var_output_name)
 
-        # file_name=os.path.join(intermediate_mosaic_dir_list[0], f'flux_{string}.img')
-        # flux_output_name=os.path.join(total_dir, f'flux_{string}.img')
-        # input=dict(infile=file_name, outfile=flux_output_name)
         file_name = intermediate_mosaic_dir_list[0].joinpath(f"flux_{string}.img")
         flux_output_name = total_dir.joinpath(f"flux_{string}.img")
         shutil.copy(file_name, flux_output_name)

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -499,8 +499,16 @@ def group_outventory(
             # clear the directory
             dirtest(savedir)
 
+            #get the number of iterations we need to do in teh loop below
+            if not time_bins_is_list:
+                #this is to account for the fact that we have the array consting of the start/end edges all in one
+                loop_iters = len(time_bins) - 1
+            else:
+                #this accounts for having the list of just the starting bin edges or the end bin edges
+                loop_iters = len(time_bins)
+
             # loop over time bins to select the appropriate outventory enteries
-            for i in range(len(time_bins) - 1):
+            for i in range(loop_iters):
                 # print(i)
                 if not time_bins_is_list:
                     start = time_bins[i]

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -372,10 +372,17 @@ def group_outventory(
                     "The end_datetime variable needs to be an astropy Time object."
                 )
     else:
-        if type(bins_datetime) is not Time:
+        if type(bins_datetime) is not Time or type(bins_datetime) is not list:
                 raise ValueError(
-                    "The bins_datetime variable needs to be an astropy Time object."
+                    "The bins_datetime variable needs to be an astropy Time object or a list of astropy Time objects."
                 )
+        #make sure that all elements of list are astropy time objects
+        if type(bins_datetime) is list:
+            for i in list:
+                if type(i) is not Time:
+                    raise ValueError(
+                        "All the list elements of the bins_datetime variable needs to be an astropy Time object."
+                    )
 
     # initalize the reference time for the Swift MET time (starts from 2001), used to calculate MET
     reference_time = Time("2001-01-01")

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -293,10 +293,10 @@ def select_outventory(outventory_file, start_met, end_met):
     #replace the ftselect with astropy fits operations
     output_file = str(outventory_file).replace(".fits", "_sel.fits")
     with fits.open(outventory_file) as f:
-        #identify the lines with the times of interest/images that are good
+        #identify the lines with the times of interest/images that are good and have the comparison be broadcastable
         idx = np.where(
-            (f[1].data["TSTART"] >= start_met) & (f[1].data["TSTART"] < end_met) &
-            (f[1].data["IMAGE_STATUS"] == True))
+            (f[1].data["TSTART"][..., None] >= start_met) & (f[1].data["TSTART"][..., None] < end_met) &
+            (f[1].data["IMAGE_STATUS"][..., None] == True))
 
         #save the headers of the original outventory file and then copy them to the new output file
         hdu = f[1]

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -272,7 +272,7 @@ def merge_outventory(survey_list, savedir=None):
 
     output_file = savedir.joinpath(
         "outventory_all.fits"
-    )  
+    )
 
     shutil.copy(survey_list[0].result_dir.joinpath("stats_point.fits"),output_file)
     for i in survey_list[1:]:
@@ -302,8 +302,10 @@ def select_outventory(outventory_file, start_met, end_met):
     in MET units. This function produces a fits file with the observations that fall between the start and end times.
 
     :param outventory_file: a Path object that points to the outventory file with all the observations of interest.
-    :param start_met: The start time in MET to select observations from the outventry file
-    :param end_met: The end time in MET to select observations from the outventory file
+    :param start_met: The start time in MET to select observations from the outventory file. This can be an array of
+        start bin edges.
+    :param end_met: The end time in MET to select observations from the outventory file. This can be an array of
+        start bin edges.
     :return: None
     """
 
@@ -336,14 +338,35 @@ def group_outventory(
     may fall within. this function creates a "grouped_outventory" directory in the folder that the outventory folder will
 
     :param outventory_file: a Path object that points to the outventory file with all the observations of interest.
-    :param binning_timedelta:  a numpy delta64 object that denotes the with of each itme bin of interest. In typical
+    :param binning_timedelta:  a numpy delta64 object that denotes the width of each time bin of interest. In typical
         BAT survey papers this is a month but different time bins can be used.
     :param start_datetime: An astropy Time object that denotes the start date to start binning the observations
     :param end_datetime: An astropy Time object that denotes the end date to stop binning the observations
     :param recalc: Boolean to denote if the directoruy at is created or not. Also denotes if the
-    :param mjd_savedir: Boolean to denote if the directory if the created directory has the datetime64 with the start date
+    :param mjd_savedir: Boolean to denote if the directory of the created directory has the datetime64 with the start date
         of the beginning of the timebin of interest or if the directory name is formatted with mjd time (which is useful
         for mosaicing with timebins shorter than a day)
+    :param custom_timebins: None OR
+        an array of astropy Time values denoting the timebin edges for which mosaicing will take place.
+            ie if custom_timebins=astropy.Time(["2022-10-08","2022-10-10", "2022-10-12"]) then there will be 2 grouped outventory files
+            (and thus mosaics) will be created.
+        OR a list of N astropy Time arrays each with shape (2 x T) where N grouped outventory files will be created (and thus
+        mosaics will be created) where the selected observation times correspond to the time bin edges denoted by the single
+        (2 x T) array. The astropy Time array should be formatted such that row 0 (indexed as [0,:]) contains all the
+        start times of the edges of the timebins of interest which will be mosaiced together. The row 1 of the astropy
+        Time array (indexed as [1,:]) contains all the end times of the edges of the timebins of interest which will be mosaiced together.
+            ie if tbins=[
+                Time([["2022-10-08","2022-10-11"],
+                    ["2022-10-10", "2022-10-12"]]),
+                Time([["2022-10-10"],
+                    ["2022-10-11"]])]
+
+                then there will be 2 mosaics created. Mosaic 1 will combine observations from 2022-10-08 to 2022-10-10 AND observations
+                from 2022-10-11 to 2022-10-12. While mosaic 2 will combine observations from 2022-10-10 to
+                2022-10-11.
+    :param save_group_outventory: a Boolean that denotes whether the grouped outventory files for each time bin and the associated
+        directories to hold the mosaic results for the time bins will be created. If this is set to False, these will
+        not be created but the calculated time_bins will be returned
     :return: astropy Time array of the time bin edges that are created based on the user specification. This can be passed directly
         to the create_mosaic function.
     """

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -359,7 +359,7 @@ def group_outventory(
 
         time_bins_is_list=False
     else:
-        if type(bins_datetime) is not Time or type(bins_datetime) is not list:
+        if type(bins_datetime) is not Time and type(bins_datetime) is not list:
                 raise ValueError(
                     "The bins_datetime variable needs to be an astropy Time object or a list of astropy Time objects."
                 )

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -520,12 +520,12 @@ def group_outventory(
             # clear the directory
             dirtest(savedir)
 
-            #get the number of iterations we need to do in teh loop below
+            # get the number of iterations we need to do in teh loop below
             if not time_bins_is_list:
-                #this is to account for the fact that we have the array consting of the start/end edges all in one
+                # this is to account for the fact that we have the array consisting of the start/end edges all in one
                 loop_iters = len(time_bins) - 1
             else:
-                #this accounts for having the list of just the starting bin edges or the end bin edges
+                # this accounts for having the list of just the starting bin edges or the end bin edges
                 loop_iters = len(time_bins)
 
             # loop over time bins to select the appropriate outventory enteries
@@ -1125,12 +1125,31 @@ def create_mosaics(
     if catalog_file is None:
         catalog_file = Path(__file__).parent.joinpath("data/survey6b_2.cat")
 
+    # determine format of the time_bins, ie an astropy Time array or a list of astropy Time arrays
+    # no error checking here since it should be taken care of in group_outventory function
+    time_bins_is_list = False
+    if type(time_bins) is list:
+        time_bins_is_list = True
+
     intermediate_mosaic_dir_list = []
     all_mosaic_survey = []
+
+    # get the number of iterations we need to do in teh loop below
+    if not time_bins_is_list:
+        # this is to account for the fact that we have the array consisting of the start/end edges all in one
+        loop_iters = len(time_bins) - 1
+    else:
+        # this accounts for having the list of just the starting bin edges or the end bin edges
+        loop_iters = len(time_bins)
+
     # loop over the time bins
-    for i in range(len(time_bins) - 1):
-        start = time_bins[i]
-        end = time_bins[i + 1]
+    for i in range(loop_iters):
+        if not time_bins_is_list:
+            start = time_bins[i]
+            end = time_bins[i + 1]
+        else:
+            start = time_bins[i][0, 0]
+            end = time_bins[i][1, 0]
 
         if verbose:
             print(f"Working on time bins from {start} to {end}.\n")

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -478,9 +478,10 @@ def group_outventory(
         #need to convert the bins_datetime to the time_bins format which is trivial since they are already set to be that
         time_bins = bins_datetime
 
-    #need to see if time_bins is a 1D or a list of size N where there are N arrays of a set of time bins (T) that will be
-    #binned into the same mosaic eventually and used to create the grouped_outventory file.
-    # ie there will be N mosaic images from T observations.
+    #need to see if time_bins is a 1D Time array or a list of size N where there are N arrays of dimension 2xT where
+    # there are T time bins of interest that will be combined into a grouped outventory file. The index 0 of the T
+    # times should be the start of the time bin(s) of interest while the index 1 of the T times should be the end of
+    # the time bins
 
 
 
@@ -511,14 +512,14 @@ def group_outventory(
                     #t = Time(end)
                     end_met = sbu.datetime2met(end.datetime, correct=True)
                 else:
-                    start = time_bins[i][0]
-                    end = time_bins[i][1]
+                    start = time_bins[i][0,0]
+                    end = time_bins[i][1,0]
 
                     # convert the start time bins edges to met times
-                    start_met = [sbu.datetime2met(j.datetime, correct=True) for j in time_bins[i][::2]]
+                    start_met = [sbu.datetime2met(j.datetime, correct=True) for j in time_bins[i][0,:]]
 
                     # convert the end time bins edges to met times
-                    end_met = [sbu.datetime2met(j.datetime, correct=True) for j in time_bins[i][1::2]]
+                    end_met = [sbu.datetime2met(j.datetime, correct=True) for j in time_bins[i][1,:]]
 
                 select_outventory(outventory_file, start_met, end_met)
 

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -401,13 +401,13 @@ def group_outventory(
 
 
     else:
-        if type( custom_timebins) is not Time and type( custom_timebins) is not list:
+        if type(custom_timebins) is not Time and type(custom_timebins) is not list:
                 raise ValueError(
                     "The  custom_timebins variable needs to be an astropy Time object or a list of astropy Time objects."
                 )
         #make sure that all elements of list are astropy time objects and set a switch for later processing
-        if type( custom_timebins) is list:
-            for i in  custom_timebins:
+        if type(custom_timebins) is list:
+            for i in custom_timebins:
                 if type(i) is not Time:
                     raise ValueError(
                         "All the list elements of the  custom_timebins variable needs to be an astropy Time object of \
@@ -423,7 +423,7 @@ def group_outventory(
     outventory_file = Path(outventory_file)
 
     #if we dont have the actual time bins passed in we need to calcualte them
-    if  custom_timebins is None:
+    if custom_timebins is None:
         # by default use the earliest date of outventory file
         if start_datetime is None:
             # use the swift launch date

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -1140,9 +1140,9 @@ def _mosaic_loop(
 
     :param outventory_file: Path object that provides the full outventory file of the BAT survey observations that will be
         used to calculate the mosaiced images.
-    :param start: numpy datetime of the start time of the time bin that survey observations need to be made to be included
+    :param start: astropy Time of the start time of the time bin that survey observations need to be made to be included
         in that time bin's mosaiced image.
-    :param end: numpy datetime of the end time of the time bin that survey observations need to be made to be included
+    :param end: astropy Time of the end time of the time bin that survey observations need to be made to be included
         in that time bin's mosaiced image.
     :param corrections_map: numpy array with the energy dependent off-axis corrections map
     :param ra_skygrid: numpy array of the skygrid facets' RA values in degrees
@@ -1164,13 +1164,23 @@ def _mosaic_loop(
         "grouped_outventory"
     )  # os.path.join(os.path.split(outventory_file)[0], "grouped_outventory")
     output_file = savedir.joinpath(
-        outventory_file.name.replace(".fits", f"_{start.astype('datetime64[D]')}.fits")
+        outventory_file.name.replace(".fits", f"_{start.datetime64.astype('datetime64[D]')}.fits")
     )  # os.path.join(savedir, os.path.split(outventory_file)[-1].replace(".fits", "_"+str(start.astype('datetime64[D]'))+".fits"))
+    #see if we need to use the mjd time format
+    if not output_file.exists():
+        output_file = savedir.joinpath(
+            outventory_file.name.replace(".fits", f"_{start.mjd}.fits")
+        )
 
     # this is the directory of the time bin where the images will be saved
     img_dir = outventory_file.parent.joinpath(
-        f"mosaic_{start.astype('datetime64[D]')}"
+        f"mosaic_{start.datetime64.astype('datetime64[D]')}"
     )  # os.path.join(os.path.split(outventory_file)[0],'mosaic_'+str(start.astype('datetime64[D]')))
+    if not img_dir.exists():
+        img_dir = outventory_file.parent.joinpath(
+            f"mosaic_{start.mjd}"
+        )
+
 
     # make the local pfile dir if it doesnt exist and set this value
     # local_pfile_dir=load_dir.joinpath(".local_pfile")
@@ -1526,11 +1536,11 @@ def _mosaic_loop(
             )
 
             # Add info about the user specified TBIN that was used to create the mosaic
-            t = Time(start)
-            start_met = sbu.datetime2met(t.datetime)
+            #t = Time(start)
+            start_met = sbu.datetime2met(start.datetime)
 
-            t = Time(end)
-            end_met = sbu.datetime2met(t.datetime)
+            #t = Time(end)
+            end_met = sbu.datetime2met(end.datetime)
 
             model_hdr["S_TBIN"] = (start_met, "Mosaicing Start of Time Bin (MET)")
             model_hdr["E_TBIN"] = (end_met, "Mosaicing End of Time Bin (MET)")

--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -1499,7 +1499,7 @@ def _mosaic_loop(
             )
             # model_hdr['BMOSPLT']=(platform,     ' BAT mosaic processing platform') #dont need this defined? NO see finalize_mosaic where it would be removed anyway
             model_hdr["BMOSMON"] = (
-                str(start.astype("datetime64[D]")),
+                str(start.datetime64.astype("datetime64[D]")),
                 " BAT mosaic processing date",
             )
 

--- a/batanalysis/parallel.py
+++ b/batanalysis/parallel.py
@@ -351,7 +351,7 @@ def batmosaic_analysis(
         parameter
     :param outventory_file: Path object of the outventory file that contains all the BAT survey observations that will
         be used to create the mosaiced images.
-    :param time_bins: The time bin edges that the observatons in the outventory file have been grouped into
+    :param time_bins: astropy Time array of the time bin edges that are created based on the user specification of the group_outventory function
     :param catalog_file: A Path object of the catalog file that should be used to identify sources in the mosaic images. This
         will default to using the catalog file that is included with the BatAnalysis package.
     :param total_mosaic_savedir: Default None or a Path object that denotes the directory that the total "time-integrated"
@@ -382,8 +382,13 @@ def batmosaic_analysis(
         # make sure that the time bins are cleared
         for i in start_t:
             binned_savedir = outventory_file.parent.joinpath(
-                f"mosaic_{i.astype('datetime64[D]')}"
+                f"mosaic_{i.datetime64.astype('datetime64[D]')}"
             )
+            if not binned_savedir.exists():
+                binned_savedir = outventory_file.parent.joinpath(
+                    f"mosaic_{i.mjd}"
+                )
+
             dirtest(binned_savedir)
 
     all_mosaic_survey = Parallel(n_jobs=nprocs)(

--- a/batanalysis/parallel.py
+++ b/batanalysis/parallel.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import sys
 from multiprocessing.pool import ThreadPool
 from astropy.table import Table, vstack
+from astropy.time import Time
 import shutil
 import numpy as np
 
@@ -374,9 +375,26 @@ def batmosaic_analysis(
     corrections_map = read_correctionsmap()
     ra_skygrid, dec_skygrid = read_skygrids()
 
-    # get the lower and upper time limits
-    start_t = time_bins[:-1]
-    end_t = time_bins[1:]
+    # determine format of the time_bins, ie an astropy Time array or a list of astropy Time arrays
+    # no error checking here since it should be taken care of in group_outventory function
+    time_bins_is_list = False
+    if type(time_bins) is list:
+        time_bins_is_list = True
+
+    if not time_bins_is_list:
+        # get the lower and upper time limits
+        start_t = time_bins[:-1]
+        end_t = time_bins[1:]
+    else:
+        start=[]
+        end=[]
+        for i in time_bins:
+            start.append(i[0, 0])
+            end.append(i[1, 0])
+
+        start_t=Time(start)
+        end_t=Time(end)
+
 
     if recalc:
         # make sure that the time bins are cleared

--- a/batanalysis/parallel.py
+++ b/batanalysis/parallel.py
@@ -2,6 +2,13 @@
 This file holds convience functions for conveniently analyzing batches of observation IDs using the joblib module
 """
 import os
+from joblib import Parallel, delayed
+from pathlib import Path
+from multiprocessing.pool import ThreadPool
+from astropy.table import Table, vstack
+from astropy.time import Time
+import shutil
+import numpy as np
 
 from .batlib import (
     dirtest,
@@ -21,14 +28,7 @@ from .mosaic import (
     read_skygrids,
 )
 
-from joblib import Parallel, delayed
-from pathlib import Path
-import sys
-from multiprocessing.pool import ThreadPool
-from astropy.table import Table, vstack
-from astropy.time import Time
-import shutil
-import numpy as np
+
 
 
 def _remove_pfiles():

--- a/batanalysis/parallel.py
+++ b/batanalysis/parallel.py
@@ -29,11 +29,10 @@ from .mosaic import (
 )
 
 
-
-
 def _remove_pfiles():
     """
-    This function removes the pfiles located in ~/pfiles so there is no conflict with the pfiles when running things in parallel
+    This function removes the pfiles located in ~/pfiles so there is no conflict with the pfiles when running things in
+    parallel
     :return:
     """
     direc = Path("~/pfiles").expanduser().resolve()
@@ -57,16 +56,17 @@ def _create_BatSurvey(
     batsurvey code succesfully completes, otherwise it will return None.
 
     :param obs_id: string of the survey observation ID
-    :param obs_dir: None or a Path object of where the directory that the observation ID data is located. This will most likely
-        be the datadir path. None defaults to using the datadir() output
+    :param obs_dir: None or a Path object of where the directory that the observation ID data is located. This will most
+        likely be the datadir path. None defaults to using the datadir() output
     :param input_dict: The input dictionary that will be passed to the heasoft batsurvey call
-    :param recalc: Boolean False by default. The default, will cause the function to try to load a save file to save on computational
-        time. If set to True, do not try to load the results of prior calculations. Instead rerun batsurvey on the observation ID.
-    :param load_dir: Default None or a Path object. The default uses the directory as pointed to by obs_dir/obs_id+'_surveyresult'
-        to try to look for a .batsurvey file to load.
-    :param patt_noise_dir: String of the directory that holds the pre-calculated pattern noise maps for BAT. None defaults to
-            looking for the maps in a folder called: "noise_pattern_maps" located in the ba.datadir() directory. If this directory
-            doesn't exist then pattern maps are not used.
+    :param recalc: Boolean False by default. The default, will cause the function to try to load a save file to save on
+        computational time. If set to True, do not try to load the results of prior calculations. Instead rerun
+        batsurvey on the observation ID.
+    :param load_dir: Default None or a Path object. The default uses the directory as pointed to by
+        obs_dir/obs_id+'_surveyresult' to try to look for a .batsurvey file to load.
+    :param patt_noise_dir: String of the directory that holds the pre-calculated pattern noise maps for BAT.
+        None defaults to looking for the maps in a folder called: "noise_pattern_maps" located in the ba.datadir()
+        directory. If this directory doesn't exist then pattern maps are not used.
     :param verbose: Boolean False by default. Tells the code to print progress/diagnostic information.
     :return: None or a BATSurvey object
     """
@@ -108,13 +108,14 @@ def batsurvey_analysis(
 
     :param obs_id_list: list of strings that denote the observation IDs to run batsurvey on
     :param input_dict: user defined dictionary of key/value pairs that will be passed to batsurvey
-    :param recalc:  Boolean False by default. The default, will cause the function to try to load a save file to save on computational
-        time. If set to True, do not try to load the results of prior calculations. Instead rerun batsurvey on the observation ID.
-    :param load_dir: Default None or a Path object. The default uses the directory as pointed to by obs_dir/obs_id+'_surveyresult'
-        to try to look for a .batsurvey file to load.
-    :param patt_noise_dir: String of the directory that holds the pre-calculated pattern noise maps for BAT. None defaults to
-            looking for the maps in a folder called: "noise_pattern_maps" located in the ba.datadir() directory. If this directory
-            doesn't exist then pattern maps are not used.
+    :param recalc:  Boolean False by default. The default, will cause the function to try to load a save file to save
+        on computational time. If set to True, do not try to load the results of prior calculations. Instead rerun
+        batsurvey on the observation ID.
+    :param load_dir: Default None or a Path object. The default uses the directory as pointed to by
+        obs_dir/obs_id+'_surveyresult' to try to look for a .batsurvey file to load.
+    :param patt_noise_dir: String of the directory that holds the pre-calculated pattern noise maps for BAT.
+        None defaults to looking for the maps in a folder called: "noise_pattern_maps" located in the ba.datadir()
+        directory. If this directory doesn't exist then pattern maps are not used.
     :param verbose: Boolean False by default. Tells the code to print progress/diagnostic information.
     :param nprocs: The number of processes that will be run simulaneously. This number should not be larger than the
         number of CPUs that a user has available to them.
@@ -158,21 +159,25 @@ def _spectrum_analysis(
 
     :param obs: the BATSurvey object for the survey pointings that will have their spectra exttracted and fitted.
     :param source_name: String of the source name as it appears in the BAT Survey catalog
-    :param recalc: Boolean False by default. The default, will cause the function to try to load a save file to save on computational
-        time. If set to True, do not try to load the results of prior calculations. Instead rerun the fitting on the
-        pointings of the observation ID.
-    :param generic_model: Default None or a generic model that can be passed to pyXspec, see the pyXspec documentation or
-        the fit_spectrum docustring for more information on how to define this. The default None uses the basic powerlaw function (see the fit_spectrum function)
+    :param recalc: Boolean False by default. The default, will cause the function to try to load a save file to save on
+        computational time. If set to True, do not try to load the results of prior calculations. Instead rerun the
+        fitting on the pointings of the observation ID.
+    :param generic_model: Default None or a generic model that can be passed to pyXspec, see the pyXspec documentation
+        or the fit_spectrum docustring for more information on how to define this. The default None uses the basic
+        powerlaw function (see the fit_spectrum function)
     :param setPars: None or a dictionary to specify values for the pyXspec model parameters. The value of None defaults
-        to using the default parameter values found in the fit_spectrum function. More inforamtion on how to define this can
-        be found by looking at the fit_spectrum docustring or the pyXspec documentation.
-    :param fit_iterations: Integer, default 100, that defines the maximum iterations that can occur to conduct the fitting
+        to using the default parameter values found in the fit_spectrum function. More inforamtion on how to define this
+        can be found by looking at the fit_spectrum docustring or the pyXspec documentation.
+    :param fit_iterations: Integer, default 100, that defines the maximum iterations that can occur to conduct the
+        fitting
     :param use_cstat: boolean, default False, to determine if CSTAT statistics should be used. In very bright sources,
         with lots of counts this should be set to False. For sources with small counts where the errors are not expected
         to be gaussian, this should be set to True.
-    :param ul_pl_index: Float (default 2) denoting the power law photon index that will be used to obtain a flux upper limit
+    :param ul_pl_index: Float (default 2) denoting the power law photon index that will be used to obtain a flux upper
+        limit
     :param nsigma: Integer, denoting the number for sigma the user needs to justify a detection
-    :param bkg_nsigma: Integer, denoting the number of sigma the user needs to to calculate flux upper limit in case of a non detection.
+    :param bkg_nsigma: Integer, denoting the number of sigma the user needs to calculate flux upper limit in case
+        of a non detection.
 
     :return: The updated BATSurvey object with updated spectral information
     """
@@ -224,7 +229,7 @@ def _spectrum_analysis(
                             "nsigma_lg10flux_upperlim", None
                         )
                     except ValueError:
-                        # if the suorce doesnt exist, just continue
+                        # if the source doesnt exist, just continue
                         pass
 
                 # Loop over individual PHA pointings
@@ -261,7 +266,8 @@ def _spectrum_analysis(
         except FileNotFoundError as e:
             print(e)
             print(
-                f"This means that the batsurvey script didnt deem there to be good enough statistics for {source_name} in this observation ID."
+                f"This means that the batsurvey script didnt deem there to be good enough statistics for {source_name} "
+                f"in this observation ID."
             )
 
     return obs
@@ -285,22 +291,25 @@ def batspectrum_analysis(
 
     :param batsurvey_obs_list: list of BATSurvey observation objects
     :param source_name:  String of the source name as it appears in the BAT Survey catalog
-    :param recalc: Boolean False by default. The default, will cause the function to try to load a save file to save on computational
-        time. If set to True, do not try to load the results of prior calculations. Instead rerun the fitting on the
-        pointings of the observation ID.
-    :param generic_model: Default None or a generic model that can be passed to pyXspec, see the pyXspec documentation or
-        the fit_spectrum docustring for more information on how to define this. The default None uses the basic powerlaw
-        function (see the fit_spectrum function)
+    :param recalc: Boolean False by default. The default, will cause the function to try to load a save file to save on
+        computational time. If set to True, do not try to load the results of prior calculations. Instead rerun the
+        fitting on the pointings of the observation ID.
+    :param generic_model: Default None or a generic model that can be passed to pyXspec, see the pyXspec documentation
+        or the fit_spectrum docustring for more information on how to define this. The default None uses the basic
+        powerlaw function (see the fit_spectrum function)
     :param setPars: None or a dictionary to specify values for the pyXspec model parameters. The value of None defaults
-        to using the default parameter values found in the fit_spectrum function. More inforamtion on how to define this can
-        be found by looking at the fit_spectrum docustring or the pyXspec documentation.
-    :param fit_iterations: Integer, default 100, that defines the maximum iterations that can occur to conduct the fitting
+        to using the default parameter values found in the fit_spectrum function. More inforamtion on how to define this
+        can be found by looking at the fit_spectrum docustring or the pyXspec documentation.
+    :param fit_iterations: Integer, default 100, that defines the maximum iterations that can occur to conduct the
+        fitting
     :param use_cstat: boolean, default False, to determine if CSTAT statistics should be used. In very bright sources,
         with lots of counts this should be set to False. For sources with small counts where the errors are not expected
         to be gaussian, this should be set to True.
-    :param ul_pl_index: Float (default 2) denoting the power law photon index that will be used to obtain a flux upper limit
+    :param ul_pl_index: Float (default 2) denoting the power law photon index that will be used to obtain a flux upper
+        limit
     :param nsigma: Integer, denoting the number for sigma the user needs to justify a detection
-    :param bkg_nsigma: Integer, denoting the number of sigma the user needs to to calculate flux upper limit in case of a non detection.
+    :param bkg_nsigma: Integer, denoting the number of sigma the user needs to calculate flux upper limit in case of
+        a non detection.
     :param nprocs: The number of processes that will be run simulaneously. This number should not be larger than the
         number of CPUs that a user has available to them.
     :return: a list of BATSurvey objects for all the observation IDs with updated spectral information
@@ -348,16 +357,17 @@ def batmosaic_analysis(
     """
     Calculates the mosaic images in parallel.
 
-    :param batsurvey_obs_list: The list of BATSurvey objects that correpond to the observations listed in the outventory file
-        parameter
+    :param batsurvey_obs_list: The list of BATSurvey objects that correpond to the observations listed in the
+        outventory file parameter
     :param outventory_file: Path object of the outventory file that contains all the BAT survey observations that will
         be used to create the mosaiced images.
-    :param time_bins: astropy Time array of the time bin edges that are created based on the user specification of the group_outventory function
-    :param catalog_file: A Path object of the catalog file that should be used to identify sources in the mosaic images. This
-        will default to using the catalog file that is included with the BatAnalysis package.
-    :param total_mosaic_savedir: Default None or a Path object that denotes the directory that the total "time-integrated"
-        images will be saved to. The default is to place the total mosaic image in a directory called "total_mosaic"
-        located in the same directory as the outventory file.
+    :param time_bins: astropy Time array of the time bin edges that are created based on the user specification of the
+        group_outventory function
+    :param catalog_file: A Path object of the catalog file that should be used to identify sources in the mosaic images.
+        This will default to using the catalog file that is included with the BatAnalysis package.
+    :param total_mosaic_savedir: Default None or a Path object that denotes the directory that the total
+        "time-integrated" images will be saved to. The default is to place the total mosaic image in a directory
+        called "total_mosaic" located in the same directory as the outventory file.
     :param recalc: Boolean False by default. If this calculation was done previously, do not try to load the results of
         prior calculations. Instead recalculate the mosaiced images. The default, will cause the function to try to load
         a save file to save on computational time.
@@ -386,15 +396,14 @@ def batmosaic_analysis(
         start_t = time_bins[:-1]
         end_t = time_bins[1:]
     else:
-        start=[]
-        end=[]
+        start = []
+        end = []
         for i in time_bins:
             start.append(i[0, 0])
             end.append(i[1, 0])
 
-        start_t=Time(start)
-        end_t=Time(end)
-
+        start_t = Time(start)
+        end_t = Time(end)
 
     if recalc:
         # make sure that the time bins are cleared
@@ -434,8 +443,8 @@ def batmosaic_analysis(
 
     intermediate_mosaic_dir_list = [i.result_dir for i in final_mosaics]
 
-    # see if the total mosaic has been created and saved (ie there is a .batsurvey file in that directory) if there isnt,
-    # then do the full calculation or if we set recalc=True then also do the full calculation
+    # see if the total mosaic has been created and saved (ie there is a .batsurvey file in that directory) if there
+    # isnt, then do the full calculation or if we set recalc=True then also do the full calculation
     if total_mosaic_savedir is None:
         total_mosaic_savedir = intermediate_mosaic_dir_list[0].parent.joinpath(
             "total_mosaic"
@@ -444,7 +453,8 @@ def batmosaic_analysis(
         total_mosaic_savedir = Path(total_mosaic_savedir)
 
     if not total_mosaic_savedir.joinpath("batsurvey.pickle").exists() or recalc:
-        # merge all the mosaics together to get the full 'time integrated' images and convert to final files with proper units
+        # merge all the mosaics together to get the full 'time integrated' images and convert to final files with
+        # proper units
         total_dir = merge_mosaics(
             intermediate_mosaic_dir_list, savedir=total_mosaic_savedir
         )

--- a/batanalysis/plotting.py
+++ b/batanalysis/plotting.py
@@ -14,7 +14,7 @@ except ModuleNotFoundError as err:
 
 def plot_survey_lc(
     survey_obsid_list,
-    id_list=None,
+    id_list,
     energy_range=[14, 195],
     savedir=None,
     time_unit="MET",
@@ -30,7 +30,7 @@ def plot_survey_lc(
     :param survey_obsid_list: List of BatSurvey or MosaicBatSurvey objects, can also be a list of lists of BatSurvey or
         MosaicBatSurvey objects which the user would like to plot. By default each sublist will be plotted on its own
         set of axis.
-    :param id_list: List of Strings or None Denoting which sources the user wants the light curves to be plotted for
+    :param id_list: List of Strings or string denoting which source(s) the user wants the light curves to be plotted for
     :param energy_range: An array for the lower and upper energy ranges to be used.
         the default value is 14-195 keV.
     :param savedir: None or a String to denote whether the light curves should be saved (if the passed value is a string)
@@ -56,23 +56,17 @@ def plot_survey_lc(
         )
 
     # determine if the user wants to plot a specific object or list of objects
-    if id_list is None:
-        # use the ids from the *.cat files produced, these are ones that have been identified in the survey obs_id
-        # x = glob.glob(os.path.join(lc_dir, '*.cat'))
-        # id_list = [os.path.basename(i).split('.cat')[0] for i in x]
-        x = sorted(lc_dir.glob("*.cat"))
-        id_list = [i.stem for i in x]
-    else:
-        if type(id_list) is not list:
-            # it is a single string:
-            id_list = [id_list]
+    if type(id_list) is not list:
+        # it is a single string:
+        id_list = [id_list]
 
     if type(survey_obsid_list[0]) is not list:
         survey_obsid_list = [survey_obsid_list]
 
-    for observation_list in survey_obsid_list:
-        if calc_lc:
-            lc_dir = combine_survey_lc(observation_list, clean_dir=clean_dir)
+    # dont need this anymore since we use concatenate_data
+    # for observation_list in survey_obsid_list:
+    #    if calc_lc:
+    #        lc_dir = combine_survey_lc(observation_list, clean_dir=clean_dir)
         # else:
         # get the main directory where we shoudl create the total_lc directory
         # main_dir = os.path.split(observation_list[0].result_dir)[0]
@@ -182,7 +176,6 @@ def plot_survey_lc(
                     fig, axes = plt.subplots(len(base_values), sharex=True)
 
             axes_queue = [i for i in range(len(base_values))]
-            # plot_value=[i for i in values]
 
             e_range_str = f"{np.min(energy_range)}-{np.max(energy_range)} keV"
             axes[0].set_title(source + "; survey data from " + e_range_str)
@@ -239,7 +232,6 @@ def plot_survey_lc(
             mjdtime = met2mjd(T0)
             utctime = met2utc(T0, mjd_time=mjdtime)
 
-            # if T0==0:
             if "MET" in time_unit:
                 label_string = "MET Time (s)"
                 val = T0
@@ -268,14 +260,12 @@ def plot_survey_lc(
 
             if savedir is not None and not same_figure:
                 plot_filename = source + "_survey_lc.pdf"
-                # fig.savefig(os.path.join(savedir, plot_filename), bbox_inches="tight")
                 fig.savefig(savedir.joinpath(plot_filename), bbox_inches="tight")
 
             obs_list_count += 1
 
         if savedir is not None and same_figure:
             plot_filename = source + "_survey_lc.pdf"
-            # fig.savefig(os.path.join(savedir, plot_filename), bbox_inches="tight")
             fig.savefig(savedir.joinpath(plot_filename), bbox_inches="tight")
 
         plt.show()

--- a/batanalysis/plotting.py
+++ b/batanalysis/plotting.py
@@ -31,14 +31,15 @@ def plot_survey_lc(
     :param id_list: List of Strings or string denoting which source(s) the user wants the light curves to be plotted for
     :param energy_range: An array for the lower and upper energy ranges to be used.
         the default value is 14-195 keV.
-    :param savedir: None or a String to denote whether the light curves should be saved (if the passed value is a string)
+    :param savedir: None or a String to denote whether the light curves should be saved
+        (if the passed value is a string)
         or not. If the value is a string, the light curve plots are saved to the provided directory if it exists.
     :param time_unit: String specifying the time unit of the light curve. Can be "MET", "UTC" or "MJD"
     :param values: A list of strings contaning information that the user would like to be plotted out. The strings
         correspond to the keys in the pointing_info dictionaries of each BatSurvey object or to 'rate' or 'snr'.
     :param T0: None or a MET time of interest that should be highlighted on the plot.
-    :param same_figure: Boolean to denote if the passed in list of BatSurvey lists should be plotted on the same set of axis,
-        alongside one another. Default is False.
+    :param same_figure: Boolean to denote if the passed in list of BatSurvey lists should be plotted on the same set of
+        axis, alongside one another. Default is False.
     :return: None
     """
 

--- a/batanalysis/plotting.py
+++ b/batanalysis/plotting.py
@@ -1,10 +1,7 @@
 from matplotlib import pyplot as plt
-import os
-import glob
 import numpy as np
-from astropy.io import fits
 from pathlib import Path
-from .batlib import combine_survey_lc, read_lc_data, met2utc, met2mjd, concatenate_data
+from .batlib import combine_survey_lc, met2utc, met2mjd, concatenate_data
 from astropy.time import Time, TimeDelta
 
 # for python>3.6

--- a/batanalysis/plotting.py
+++ b/batanalysis/plotting.py
@@ -20,8 +20,6 @@ def plot_survey_lc(
     time_unit="MET",
     values=["rate", "snr"],
     T0=None,
-    calc_lc=False,
-    clean_dir=False,
     same_figure=False,
 ):
     """
@@ -39,9 +37,6 @@ def plot_survey_lc(
     :param values: A list of strings contaning information that the user would like to be plotted out. The strings
         correspond to the keys in the pointing_info dictionaries of each BatSurvey object or to 'rate' or 'snr'.
     :param T0: None or a MET time of interest that should be highlighted on the plot.
-    :param calc_lc: Boolean set to True, to denote if the light curves across all the BatSurvey objects need to be recombined
-    :param clean_dir: Boolean set to True by default. Denotes if the whole directory that holds all the compiled light curve
-        data for the passed survey observations should be deleted and recreated if the directory exists.
     :param same_figure: Boolean to denote if the passed in list of BatSurvey lists should be plotted on the same set of axis,
         alongside one another. Default is False.
     :return: None
@@ -62,15 +57,6 @@ def plot_survey_lc(
 
     if type(survey_obsid_list[0]) is not list:
         survey_obsid_list = [survey_obsid_list]
-
-    # dont need this anymore since we use concatenate_data
-    # for observation_list in survey_obsid_list:
-    #    if calc_lc:
-    #        lc_dir = combine_survey_lc(observation_list, clean_dir=clean_dir)
-        # else:
-        # get the main directory where we shoudl create the total_lc directory
-        # main_dir = os.path.split(observation_list[0].result_dir)[0]
-        # lc_dir = observation_list[0].result_dir.parent.joinpath("total_lc") #os.path.join(main_dir, "total_lc")
 
     # if the user wants to save the plots check if the save dir exists
     if savedir is not None:

--- a/batanalysis/plotting.py
+++ b/batanalysis/plotting.py
@@ -1,7 +1,7 @@
 from matplotlib import pyplot as plt
 import numpy as np
 from pathlib import Path
-from .batlib import combine_survey_lc, met2utc, met2mjd, concatenate_data
+from .batlib import met2utc, met2mjd, concatenate_data
 from astropy.time import Time, TimeDelta
 
 # for python>3.6


### PR DESCRIPTION
Previously, users could only have uniform binning be used to construct mosaics from observations. Now, users are able to construct mosaics using custom time binning and can denote that the mosaic directories be formatted with MJD time which allows for shorter mosaicing time bins. 