### PR TITLE
Correctly check for 1M np.timedelta64 and added new option to skip computation of the total mosaic

### DIFF
--- a/batanalysis/mosaic.py
+++ b/batanalysis/mosaic.py
@@ -444,7 +444,8 @@ def group_outventory(
             with fits.open(outventory_file) as f:
                 end_datetime = Time(met2utc(f[1].data["TSTART"].max()))
 
-        if binning_timedelta == np.timedelta64(1, "M"):
+        if np.dtype(binning_timedelta) == np.dtype(np.timedelta64(1, 'M')) and binning_timedelta == np.timedelta64(1,
+                                                                                                                   'M'):
             # if the user wants months, need to specify each year, month and the number of days
             years = [
                 i


### PR DESCRIPTION
This is from PR #21 excluding the nprocs=1 commits that were made. this fixes the numpy timedelta64 comparison between 1 month and other formats. This also allows users to skip the computation of the total mosaic if it is not needed in the parallel mosaic computation. 