### PR TITLE
fix deprecated pkg_resources in higher version of setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools>=58.0.4
+setuptools>=58.0.4,<82.0.0
 numpy>=1.24.4
 matplotlib>=3.4.2
 astropy>=4.3.1


### PR DESCRIPTION
setuptools>82.0.0 has removed pkg_resources module, which cause:

ModuleNotFoundError: No module named 'pkg_resources'

this commit adds upper limit of setuptools version